### PR TITLE
Problem: case-sensitive compare on message names

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -196,7 +196,7 @@ CZMQ_EXPORT $(class.name)_t *
 
 //  Print contents of message to stdout
 CZMQ_EXPORT void
-    $(class.name)_dump ($(class.name)_t *self);
+    $(class.name)_print ($(class.name)_t *self);
 
 //  Get/set the message routing id
 CZMQ_EXPORT zframe_t *
@@ -1098,7 +1098,7 @@ $(class.name)_recv (void *input)
     assert (input);
     zmsg_t *msg = zmsg_recv (input);
 .if switches.trace ?= 1
-    zmsg_dump (msg);
+    zmsg_print (msg);
 .endif
     //  If message came from a router socket, first frame is routing_id
     zframe_t *routing_id = NULL;
@@ -1126,7 +1126,7 @@ $(class.name)_recv_nowait (void *input)
     assert (input);
     zmsg_t *msg = zmsg_recv_nowait (input);
 .if switches.trace ?= 1
-    zmsg_dump (msg);
+    zmsg_print (msg);
 .endif
     //  If message came from a router socket, first frame is routing_id
     zframe_t *routing_id = NULL;
@@ -1389,7 +1389,7 @@ $(class.name)_dup ($(class.name)_t *self)
 .for class.field where type = "dictionary"
 //  Dump $(name) key=value pair to stdout
 static int
-s_$(name)_dump (const char *key, void *item, void *argument)
+s_$(name)_print (const char *key, void *item, void *argument)
 {
     printf ("        %s=%s\\n", key, (char *) item);
     return 0;
@@ -1401,7 +1401,7 @@ s_$(name)_dump (const char *key, void *item, void *argument)
 //  Print contents of message to stdout
 
 void
-$(class.name)_dump ($(class.name)_t *self)
+$(class.name)_print ($(class.name)_t *self)
 {
     assert (self);
 .if class.has_repeats
@@ -1498,7 +1498,7 @@ $(class.name)_dump ($(class.name)_t *self)
 .       elsif type = "dictionary"
             printf ("    $(name)={\\n");
             if (self->$(name))
-                zhash_foreach (self->$(name), s_$(name)_dump, self);
+                zhash_foreach (self->$(name), s_$(name)_print, self);
             else
                 printf ("(NULL)\\n");
             printf ("    }\\n");
@@ -1532,7 +1532,7 @@ $(class.name)_dump ($(class.name)_t *self)
 .       elsif type = "msg"
             printf ("    $(name)={\\n");
             if (self->$(name))
-                zmsg_dump (self->$(name));
+                zmsg_print (self->$(name));
             else
                 printf ("(NULL)\\n");
             printf ("    }\\n");

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -25,6 +25,11 @@ for class.state
     endfor
 endfor
 
+#   Lowecase protocol message names
+for proto.message
+    message.name = "$(name)"
+endfor
+
 #   API methods that get passed to server task
 for class.method
    if return ?= "number"
@@ -688,18 +693,22 @@ s_client_filter_mailbox (s_client_t *self)
         //  Check whether current state can process event
         //  This should be changed to a pre-built lookup table
         event_t event = s_protocol_event (request);
-        bool event_is_valid = false;
+        bool event_is_valid;
 .for class.state
 .   if count (event, event.name = "*")
         if (self->state == $(state.name:c)_state)
             event_is_valid = true;
+        else
 .   else
 .       for event where defined (external)
         if (self->state == $(state.name:c)_state && event == $(name:c)_event)
             event_is_valid = true;
+        else
 .       endfor
 .   endif
 .endfor
+            event_is_valid = false;
+            
         if (event_is_valid) {
             zlist_remove (self->mailbox, request);
             $(proto)_destroy (&self->client.request);
@@ -723,7 +732,7 @@ s_client_filter_mailbox (s_client_t *self)
 .               if switches.trace ?= 1
                         zlog_debug (self->server->log,
                             "%s: Send message to client", self->log_prefix);
-                        $(proto)_dump (self->client.reply);
+                        $(proto)_print (self->client.reply);
 .               endif
                         $(proto)_send (&self->client.reply, self->server->router);
                         self->client.reply = $(proto)_new (0);
@@ -983,8 +992,8 @@ s_server_control_message (zloop_t *loop, zmq_pollitem_t *item, void *argument)
     if (!msg)
         return -1;              //  Interrupted; exit zloop
 .if switches.trace ?= 1
-    zlog_debug (self->server->log, "API command:");
-    zmsg_dump (msg);
+    zlog_debug (self->log, "API command:");
+    zmsg_print (msg);
 .endif
 .for class.method
     if (streq (method, "$(NAME)")) {
@@ -1088,8 +1097,8 @@ s_server_client_message (zloop_t *loop, zmq_pollitem_t *item, void *argument)
     }
     free (hashkey);
 .if switches.trace ?= 1
-    zlog_debug (self->server->log, "%s: Client message", client->unique_id);
-    $(proto)_dump (msg);
+    zlog_debug (self->log, "%d: Client message", client->unique_id);
+    $(proto)_print (msg);
 .endif
 
 .   if count (class.event, name = "expired")


### PR DESCRIPTION
Borks up code generation when we use uppercase in messages as well
as in state machine.

Solution: convert message names to lowercase before using in FSM
code generator (as already done for event names).
