### PR TITLE
Can't bind to DNS name

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -1285,12 +1285,12 @@ $(class.name)_test (bool verbose)
 
     $(class.name)_t *self = $(class.name)_new ();
     assert (self);
-    $(class.name)_bind (self, "tcp://localhost:5670");
+    $(class.name)_bind (self, "tcp://127.0.0.1:5670");
 
     void *dealer = zsocket_new (ctx, ZMQ_DEALER);
     assert (dealer);
     zsocket_set_rcvtimeo (dealer, 2000);
-    zsocket_connect (dealer, "tcp://localhost:5670");
+    zsocket_connect (dealer, "tcp://127.0.0.1:5670");
 
     $(proto)_t *request, *reply;
     request = $(proto)_new ($(PROTO)_something);


### PR DESCRIPTION
I don't know why this code said 'localhost', that's a known no-no. We use 127.0.0.1 in other places; safe to bind and to connect to, on all systems, without opening external ports.
