### PR TITLE
Switched to new zsys logging facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,14 +190,6 @@ Your server code (the actions) gets a small API to work with:
     static void
     engine_broadcast_event (server_t *server, client_t *client, event_t event);
 
-    //  Send log data to the server log. Accepts a printf format.
-    static void
-    engine_log (client_t *client, const char format, ...);
-
-    //  Send log data to the server log. Accepts a printf format.
-    static void
-    engine_server_log (server_t *server, const char *format, ...);
-
     //  Set log file prefix; this string will be added to log data, to make
     //  log data more searchable. The string is truncated to ~20 chars.
     static void

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -806,35 +806,13 @@ $(class.name)_decode (zmsg_t **msg_p)
 
     //  Error returns
     malformed:
-        printf ("E: malformed message '%d'\\n", self->id);
+        zsys_error ("malformed message '%d'\\n", self->id);
     empty:
         zframe_destroy (&frame);
         zmsg_destroy (msg_p);
         $(class.name)_destroy (&self);
         return (NULL);
 }
-.for class.field where type = "dictionary"
-
-//  Count size of key/value pair for serialization
-//  Key is encoded as string, value as longstr
-static int
-s_$(name)_count (const char *key, void *item, void *argument)
-{
-    $(class.name)_t *self = ($(class.name)_t *) argument;
-    self->$(name)_bytes += 1 + strlen (key) + 4 + strlen ((char *) item);
-    return 0;
-}
-
-//  Serialize $(name) key=value pair
-static int
-s_$(name)_write (const char *key, void *item, void *argument)
-{
-    $(class.name)_t *self = ($(class.name)_t *) argument;
-    PUT_STRING (key);
-    PUT_LONGSTR ((char *) item);
-    return 0;
-}
-.endfor
 
 
 //  --------------------------------------------------------------------------
@@ -938,7 +916,12 @@ $(class.name)_encode ($(class.name)_t **self_p)
             if (self->$(name)) {
                 self->$(name)_bytes = 0;
                 //  Add up size of dictionary contents
-                zhash_foreach (self->$(name), s_$(name)_count, self);
+                char *item = (char *) zhash_first (self->$(name));
+                while (item) {
+                    self->$(name)_bytes += 1 + strlen (zhash_cursor (self->$(name)));
+                    self->$(name)_bytes += 4 + strlen (item);
+                    item = (char *) zhash_next (self->$(name));
+                }
             }
             frame_size += self->$(name)_bytes;
 .       elsif type = "chunk"
@@ -955,7 +938,7 @@ $(class.name)_encode ($(class.name)_t **self_p)
             
 .endfor
         default:
-            printf ("E: bad message type '%d', not sent\\n", self->id);
+            zsys_error ("bad message type '%d', not sent\\n", self->id);
             //  No recovery, this is a fatal application error
             assert (false);
     }
@@ -1057,7 +1040,12 @@ $(class.name)_encode ($(class.name)_t **self_p)
 .       elsif type = "dictionary"
             if (self->$(name)) {
                 PUT_NUMBER4 (zhash_size (self->$(name)));
-                zhash_foreach (self->$(name), s_$(name)_write, self);
+                char *item = (char *) zhash_first (self->$(name));
+                while (item) {
+                    PUT_STRING (zhash_cursor (self->$(name)));
+                    PUT_LONGSTR (item);
+                    item = (char *) zhash_next (self->$(name));
+                }
             }
             else
                 PUT_NUMBER4 (0);    //  Empty dictionary
@@ -1419,17 +1407,6 @@ $(class.name)_dup ($(class.name)_t *self)
 }
 
 
-.for class.field where type = "dictionary"
-//  Dump $(name) key=value pair to stdout
-static int
-s_$(name)_print (const char *key, void *item, void *argument)
-{
-    printf ("        %s=%s\\n", key, (char *) item);
-    return 0;
-}
-
-.endfor
-
 //  --------------------------------------------------------------------------
 //  Print contents of message to stdout
 
@@ -1447,148 +1424,127 @@ $(class.name)_print ($(class.name)_t *self)
 .   for field
 .       if type = "number"
 .           if defined (field.value)
-            printf ("    $(name)=$(field.value)\\n");
+            zsys_debug ("    $(name)=$(field.value)");
 .           elsif defined (repeat)
-            printf ("   $(name)=[");
-            for (index = 0; index < self->$(name)_index + 1; index++) {
-                printf ("%ld", (long) self->$(name));
-                if (index < self->$(name)_index - 1)
-                    printf (",");
-            }
-            printf ("]\\n");
+            zsys_debug ("   $(name)=[");
+            for (index = 0; index < self->$(name)_index + 1; index++)
+                zsys_debug ("%ld", (long) self->$(name));
+            zsys_debug ("]");
 .           else
-            printf ("    $(name)=%ld\\n", (long) self->$(name));
+            zsys_debug ("    $(name)=%ld", (long) self->$(name));
 .           endif
 .       elsif type = "octets"
-            printf ("    $(name)=[");
-.           if defined (repeat)
-            for (index = 0; index < self->$(name)_index + 1; index++) {
-                int $(name)_index;
-                printf ("{");
-                for ($(name)_index = 0; $(name)_index < $(size); $(name)_index++) {
-                    if ($(name)_index && ($(name)_index % 4 == 0))
-                        printf ("-");
-                    printf ("%02X", self->$(name) [index] [$(name)_index]);
-                }
-                printf ("}");
-            }
-            printf (" ]\\n");
-.           else
-            int $(name)_index;
-            for ($(name)_index = 0; $(name)_index < $(size); $(name)_index++) {
-                if ($(name)_index && ($(name)_index % 4 == 0))
-                    printf ("-");
-                printf ("%02X", self->$(name) [$(name)_index]);
-            }
-        printf ("\\n");
-.           endif           
+            zsys_debug ("    $(name)=[ ... ]");
 .       elsif type = "string" | type = "longstr"
 .           if defined (field.value)
-            printf ("    $(name)=$(field.value)\\n");
+            zsys_debug ("    $(name)=$(field.value)");
 .           elsif defined (repeat)
-            printf ("$(name)=[");
+            zsys_debug ("$(name)=[");
             for (index = 0; index < self->$(name)_index + 1; index++) {
                 if (self->$(name) [index])
-                    printf (" '%s'", self->$(name) [index]);
+                    zsys_debug (" '%s'", self->$(name) [index]);
                 else
-                    printf (" ");
-                if (index < self->$(name)_index - 1)
-                    printf (",");
+                    zsys_debug (" ");
             }
-            printf (" ]\\n");
+            zsys_debug (" ]");
 .           else
             if (self->$(name))
-                printf ("    $(name)='%s'\\n", self->$(name));
+                zsys_debug ("    $(name)='%s'", self->$(name));
             else
-                printf ("    $(name)=\\n");
+                zsys_debug ("    $(name)=");
 .           endif
 .       elsif type = "strings"
 .           if defined (repeat)
-            printf ("    $(name)=[");
+            zsys_debug ("    $(name)=[");
             for (index = 0; index < self->$(name)_index + 1; index++) {
-                printf ("{");
+                zsys_debug ("{");
                 if (self->$(name) [index]) {
                     char *$(name) = (char *) zlist_first (self->$(name) [index]);
                     while ($(name)) {
-                        printf (" '%s'", $(name));
+                        zsys_debug (" '%s'", $(name));
                         $(name) = (char *) zlist_next (self->$(name) [index]);
                     }
                 }
-                printf (" }\\n");
+                zsys_debug (" }");
             }
-            printf ("]\\n");
+            zsys_debug ("]");
 .           else                
-            printf ("    $(name)={");
+            zsys_debug ("    $(name)={");
             if (self->$(name)) {
                 char *$(name) = (char *) zlist_first (self->$(name));
                 while ($(name)) {
-                    printf (" '%s'", $(name));
+                    zsys_debug (" '%s'", $(name));
                     $(name) = (char *) zlist_next (self->$(name));
                 }
             }
-            printf (" }\\n");
+            zsys_debug (" }");
 .           endif            
 .       elsif type = "dictionary"
-            printf ("    $(name)={\\n");
-            if (self->$(name))
-                zhash_foreach (self->$(name), s_$(name)_print, self);
+            zsys_debug ("    $(name)={");
+            if (self->$(name)) {
+                char *item = (char *) zhash_first (self->$(name));
+                while (item) {
+                    zsys_debug ("        %s=%s", zhash_cursor (self->$(name)), item);
+                    item = (char *) zhash_next (self->$(name));
+                }
+            }
             else
-                printf ("(NULL)\\n");
-            printf ("    }\\n");
+                zsys_debug ("(NULL)");
+            zsys_debug ("    }");
 .       elsif type = "chunk"
 .           if defined (repeat)
-            printf ("    $(name)=[");
+            zsys_debug ("    $(name)=[");
             for (index = 0; index < self->$(name)_index + 1; index++) {
-                printf ("    {\\n");
+                zsys_debug ("    {");
                 if (self->$(name) [index])
                     zchunk_print (self->$(name) [index]);
                 else
-                    printf ("(NULL)\\n");
-                printf ("    }\\n");
+                    zsys_debug ("(NULL)");
+                zsys_debug ("    }");
             }
-            printf ("]\\n");
+            zsys_debug ("]");
 .           else            
-            printf ("    $(name)={\\n");
+            zsys_debug ("    $(name)={");
             if (self->$(name))
                 zchunk_print (self->$(name));
             else
-                printf ("(NULL)\\n");
-            printf ("    }\\n");
+                zsys_debug ("(NULL)");
+            zsys_debug ("    }");
 .           endif            
 .       elsif type = "uuid"
-            printf ("    $(name)=[");
+            zsys_debug ("    $(name)=[");
 .           if defined (repeat)
             for (index = 0; index < self->$(name)_index + 1; index++) {
-                printf ("    {\\n");
+                zsys_debug ("    {");
                 if (self->$(name) [index])
-                    printf ("%s", zuuid_str (self->$(name) [index]));
+                    zsys_debug ("%s", zuuid_str (self->$(name) [index]));
                 else
-                    printf ("(NULL)\\n");
-                printf ("    }\\n");
+                    zsys_debug ("(NULL)");
+                zsys_debug ("    }");
             }
-            printf ("]\\n");
+            zsys_debug ("]");
 .           else            
-            printf ("    $(name)={\\n");
+            zsys_debug ("    $(name)={");
             if (self->$(name))
-                printf ("%s", zuuid_str (self->$(name)));
+                zsys_debug ("%s", zuuid_str (self->$(name)));
             else
-                printf ("(NULL)\\n");
-            printf ("    }\\n");
+                zsys_debug ("(NULL)");
+            zsys_debug ("    }");
 .           endif            
 .       elsif type = "frame"
-            printf ("    $(name)={\\n");
+            zsys_debug ("    $(name)={");
             if (self->$(name))
                 zframe_print (self->$(name), NULL);
             else
-                printf ("(NULL)\\n");
-            printf ("    }\\n");
+                zsys_debug ("(NULL)");
+            zsys_debug ("    }");
 .       elsif type = "msg"
-            printf ("    $(name)={\\n");
+            zsys_debug ("    $(name)={");
             if (self->$(name))
                 zmsg_print (self->$(name));
             else
-                printf ("(NULL)\\n");
-            printf ("    }\\n");
+                zsys_debug ("(NULL)");
+            zsys_debug ("    }");
 .       endif
 .   endfor
             break;

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -190,7 +190,6 @@ typedef struct {
     zloop_t *loop;              //  Reactor for server sockets
     zhash_t *clients;           //  Clients we're connected to
     zconfig_t *config;          //  Configuration tree
-    zlog_t *log;                //  Server logger
     uint client_id;             //  Client identifier counter
     size_t timeout;             //  Default client expiry timeout
     bool animate;               //  Is animation enabled?
@@ -350,39 +349,6 @@ engine_set_monitor (server_t *server, size_t interval, zloop_timer_fn monitor)
     }
 }
 
-//  Send log data for a specific client to the server log. Accepts a
-//  printf format.
-
-static void
-engine_log (client_t *client, const char *format, ...)
-{
-    if (client) {
-        s_client_t *self = (s_client_t *) client;
-        va_list argptr;
-        va_start (argptr, format);
-        char *string = zsys_vprintf (format, argptr);
-        va_end (argptr);
-        zlog_debug (self->server->log, "%s: %s", self->log_prefix, string);
-        free (string);
-    }
-}
-
-//  Send log data to the server log. Accepts a printf format.
-
-static void
-engine_server_log (server_t *server, const char *format, ...)
-{
-    if (server) {
-        s_server_t *self = (s_server_t *) server;
-        va_list argptr;
-        va_start (argptr, format);
-        char *string = zsys_vprintf (format, argptr);
-        va_end (argptr);
-        zlog_debug (self->log, "%s", string);
-        free (string);
-    }
-}
-
 //  Set log file prefix; this string will be added to log data, to make
 //  log data more searchable. The string is truncated to ~20 chars.
 
@@ -423,8 +389,6 @@ s_satisfy_pedantic_compilers (void)
     engine_broadcast_event (NULL, NULL, 0);
     engine_handle_socket (NULL, 0, NULL);
     engine_set_monitor (NULL, 0, NULL);
-    engine_log (NULL, NULL);
-    engine_server_log (NULL, NULL);
     engine_set_log_prefix (NULL, NULL);
     engine_configure (NULL, NULL, NULL);
 }
@@ -565,12 +529,11 @@ s_client_filter_mailbox (s_client_t *self)
 .           if name = "send"
                         //  send $(message:c)
                         if (self->server->animate)
-                            zlog_debug (self->server->log,
-                                "%s:         $ $(name) $(MESSAGE:c)", self->log_prefix);
+                            zsys_debug ("%s:         $ $(name) $(MESSAGE:c)",
+                                self->log_prefix);
                         $(proto)_set_id (self->client.reply, $(PROTO)_$(MESSAGE:C));
 .               if switches.trace ?= 1
-                        zlog_debug (self->server->log,
-                            "%s: Send message to client", self->log_prefix);
+                        zsys_debug ("%s: Send message to client", self->log_prefix);
                         $(proto)_print (self->client.reply);
 .               endif
                         $(proto)_send (&self->client.reply, self->server->router);
@@ -579,14 +542,12 @@ s_client_filter_mailbox (s_client_t *self)
 .           elsif name = "terminate"
                         //  terminate
                         if (self->server->animate)
-                            zlog_debug (self->server->log,
-                                "%s:         $ $(name)", self->log_prefix);
+                            zsys_debug ("%s:         $ $(name)", self->log_prefix);
                         self->next_event = terminate_event;
 .           else
                         //  $(name)
                         if (self->server->animate)
-                            zlog_debug (self->server->log,
-                                "%s:         $ $(name)", self->log_prefix);
+                            zsys_debug ("%s:         $ $(name)", self->log_prefix);
                         $(name:c) (&self->client);
 .           endif
                     }
@@ -613,10 +574,10 @@ s_client_execute (s_client_t *self, int event)
         self->next_event = NULL_event;
         self->exception = NULL_event;
         if (self->server->animate) {
-            zlog_debug (self->server->log,
-                "%s: %s:", self->log_prefix, s_state_name [self->state]);
-            zlog_debug (self->server->log,
-                "%s:     %s", self->log_prefix, s_event_name [self->event]);
+            zsys_debug ("%s: %s:",
+                self->log_prefix, s_state_name [self->state]);
+            zsys_debug ("%s:     %s",
+                self->log_prefix, s_event_name [self->event]);
         }
         switch (self->state) {
 .for class.state
@@ -644,7 +605,7 @@ s_client_execute (s_client_t *self, int event)
 .   else
                 else {
                     //  Handle unexpected internal events
-                    zlog_warning (self->server->log, "%s: unhandled event %s in %s",
+                    zsys_warning ("%s: unhandled event %s in %s",
                         self->log_prefix,
                         s_event_name [self->event],
                         s_state_name [self->state]);
@@ -657,8 +618,7 @@ s_client_execute (s_client_t *self, int event)
         //  If we had an exception event, interrupt normal programming
         if (self->exception) {
             if (self->server->animate)
-                zlog_debug (self->server->log,
-                    "%s:         ! %s",
+                zsys_debug ("%s:         ! %s",
                     self->log_prefix, s_event_name [self->exception]);
 
             self->next_event = self->exception;
@@ -670,8 +630,7 @@ s_client_execute (s_client_t *self, int event)
         }
         else {
             if (self->server->animate)
-                zlog_debug (self->server->log,
-                    "%s:         > %s",
+                zsys_debug ("%s:         > %s",
                     self->log_prefix, s_state_name [self->state]);
 
             if (self->next_event == NULL_event)
@@ -723,7 +682,7 @@ s_server_config_self (s_server_t *self)
     int background = atoi (
         zconfig_resolve (self->config, "server/background", "0"));
     if (!background)
-        zlog_set_foreground (self->log, true);
+        zsys_set_logstream (stdout);
 }
 
 static s_server_t *
@@ -736,7 +695,6 @@ s_server_new (zsock_t *pipe)
     self->pipe = pipe;
     self->router = zsock_new (ZMQ_ROUTER);
     self->clients = zhash_new ();
-    self->log = zlog_new ("$(class.name)");
     self->config = zconfig_new ("root", NULL);
     self->loop = zloop_new ();
     srandom ((unsigned int) zclock_time ());
@@ -747,7 +705,6 @@ s_server_new (zsock_t *pipe)
     s_server_config_self (self);
 
     //  Initialize application server context
-    self->server.log = self->log;
     self->server.config = self->config;
     server_initialize (&self->server);
 
@@ -766,7 +723,6 @@ s_server_destroy (s_server_t **self_p)
         zconfig_destroy (&self->config);
         zhash_destroy (&self->clients);
         zloop_destroy (&self->loop);
-        zlog_destroy (&self->log);
         free (self);
         *self_p = NULL;
     }
@@ -787,7 +743,7 @@ s_server_apply_config (s_server_t *self)
 
     while (section) {
         if (streq (zconfig_name (section), "echo"))
-            zlog_notice (self->log, "%s", zconfig_value (section));
+            zsys_notice ("%s", zconfig_value (section));
         else
         if (streq (zconfig_name (section), "bind")) {
             char *endpoint = zconfig_resolve (section, "endpoint", "?");
@@ -809,7 +765,7 @@ s_server_api_message (zloop_t *loop, zsock_t *reader, void *argument)
     if (!msg)
         return -1;              //  Interrupted; exit zloop
 .if switches.trace ?= 1
-    zlog_debug (self->log, "API message:");
+    zsys_debug ("API message:");
     zmsg_print (msg);
 .endif
     char *method = zmsg_popstr (msg);
@@ -836,8 +792,7 @@ s_server_api_message (zloop_t *loop, zsock_t *reader, void *argument)
             self->server.config = self->config;
         }
         else {
-            zlog_warning (self->log,
-                "cannot load config file '%s'\\n", config_file);
+            zsys_warning ("cannot load config file '%s'\\n", config_file);
             self->config = zconfig_new ("root", NULL);
         }
         free (config_file);
@@ -881,7 +836,7 @@ s_server_client_message (zloop_t *loop, zsock_t *reader, void *argument)
     }
     free (hashkey);
 .if switches.trace ?= 1
-    zlog_debug (self->log, "%d: Client message", client->unique_id);
+    zsys_debug ("%d: Client message", client->unique_id);
     $(proto)_print (msg);
 .endif
 
@@ -913,7 +868,7 @@ s_watch_server_config (zloop_t *loop, int timer_id, void *argument)
     &&  zconfig_reload (&self->config) == 0) {
         s_server_config_self (self);
         self->server.config = self->config;
-        zlog_notice (self->log, "reloaded configuration from %s",
+        zsys_notice ("reloaded configuration from %s",
             zconfig_filename (self->config));
     }
     return 0;
@@ -983,7 +938,6 @@ typedef struct _client_t client_t;
 struct _server_t {
     //  These properties must always be present in the server_t
     //  and are set by the generated engine; do not modify them!
-    zlog_t *log;                //  For any logging needed
     zconfig_t *config;          //  Current loaded configuration
     
     //  Add any properties you need here


### PR DESCRIPTION
- removed all use of zlog class
- see CZMQ issue #519
- note ALL engines need to be regenerated
- removal (not deprecation) of zlog forces the change

zsys_debug/error/etc. ensure all log data is sent to same place.
This means no longer using printf/zclock_log etc. in application
code.
