### PR TITLE
Problem: cannot use zproto for CZMQ itself

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -378,7 +378,11 @@ CZMQ_EXPORT int
 @end
 */
 
-#include <czmq.h>
+.if file.exists ("../include/czmq.h")
+#include "../include/czmq.h"
+.else
+#include czmq.h>
+.endif
 #include "$(class.header)/$(class.name).h"
 
 //  Structure of our class


### PR DESCRIPTION
zproto_codec_c was assuming /usr/local/include/czmq.h, which does
not work for classes built as part of CZMQ itself (such as the
zgossip_msg) class.

Solution: check for "../include/czmq.h" and use that preferentially.
