### PR TITLE
Problem: asserting when BIND fails

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -772,8 +772,8 @@ s_server_apply_config (s_server_t *self)
         else
         if (streq (zconfig_name (section), "bind")) {
             char *endpoint = zconfig_resolve (section, "endpoint", "?");
-            int rc = zsock_bind (self->router, "%s", endpoint);
-            assert (rc != -1);
+            if (zsock_bind (self->router, "%s", endpoint) == -1)
+                zsys_warning ("failed to bind to %s", endpoint);
         }
         section = zconfig_next (section);
     }
@@ -805,7 +805,8 @@ s_server_api_message (zloop_t *loop, zsock_t *reader, void *argument)
         //  Bind to a specified endpoint, which may use an ephemeral port
         char *endpoint = zmsg_popstr (msg);
         self->port = zsock_bind (self->router, "%s", endpoint);
-        assert (self->port != -1);
+        if (self->port == -1)
+            zsys_warning ("failed to bind to %s", endpoint);
         free (endpoint);
     }
     else


### PR DESCRIPTION
This makes it harder to debug complex configuration errors; it's nicer to
show an error message and continue. Arguably, at least. We can change
this later as needed.

Solution: don't assert, log an error and continue.
