### PR TITLE
Problem: CLASS specifies generated include files as .h

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -73,6 +73,7 @@ for class.action
 endfor
 
 .endtemplate
+.#  This is the API for the server
 .output "$(class.header)/$(class.name).h"
 /*  =========================================================================
     $(class.name) - $(class.title:)
@@ -156,7 +157,7 @@ CZMQ_EXPORT void
 #endif
 
 #endif
-.output "$(class.name)_engine.h"
+.output "$(class.name)_engine.inc"
 /*  =========================================================================
     $(class.name)_engine - $(class.title:) engine
 


### PR DESCRIPTION
Server codec generated .h file.

Solution: generate .inc file according to CLASS spec.
