### PR TITLE
Hid animation semantics from API

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -112,6 +112,10 @@ extern "C" {
 //
 //      zactor_destroy (&$(class.title:c));
 //  
+//  Enable verbose logging of commands and activity:
+//
+//      zstr_send (ca, "VERBOSE");
+//
 //  Bind $(class.title) to specified endpoint. TCP endpoints may specify
 //  the port number as "*" to aquire an ephemeral port:
 //
@@ -711,10 +715,11 @@ s_server_config_self (s_server_t *self)
 {
     //  Built-in server configuration options
     //  
-    //  By default the server is silent
-    self->verbose = atoi (
-        zconfig_resolve (self->config, "server/verbose", "0")) != 0;
-
+    //  If we didn't already set verbose, check if the config tree wants it
+    if (!self->verbose
+    && atoi (zconfig_resolve (self->config, "server/verbose", "0")))
+        self->verbose = true;
+        
     //  Default client timeout is 60 seconds
     self->timeout = atoi (
         zconfig_resolve (self->config, "server/timeout", "60000"));
@@ -818,8 +823,11 @@ s_server_api_message (zloop_t *loop, zsock_t *reader, void *argument)
 .endif
     char *method = zmsg_popstr (msg);
     if (self->verbose)
-        zsys_debug ("%s:     API command=", self->log_prefix, method);
+        zsys_debug ("%s:     API command=%s", self->log_prefix, method);
     
+    if (streq (method, "VERBOSE"))
+        self->verbose = true;
+    else
     if (streq (method, "$TERM")) {
         //  Shutdown the engine
         free (method);


### PR DESCRIPTION
All other actors I'm making use the VERBOSE command to enable logging, while the server actor that zproto produces has this more intricate server/animate option. It exposes too much of the internals IMO and the inconsistency is cost for no benefit.

So I've switched zproto_server.gsl to accept VERBOSE and use that to switch on animation.
