### PR TITLE
Problem: client_terminate is crashing when using server properties

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -771,13 +771,12 @@ s_server_destroy (s_server_t **self_p)
     assert (self_p);
     if (*self_p) {
         s_server_t *self = *self_p;
+        //  Destroy clients before destroying the server
+        zhash_destroy (&self->clients);
+        server_terminate (&self->server);
         zsock_destroy (&self->router);
         zconfig_destroy (&self->config);
         zloop_destroy (&self->loop);
-        zhash_destroy (&self->clients);
-        //  Dear future self: do this last, so client_terminate
-        //  can work with server
-        server_terminate (&self->server);
         free (self);
         *self_p = NULL;
     }


### PR DESCRIPTION
The code destroyed the server (server_terminate) before destrying
the client hash, so client_terminate got a null when trying to use
any server property.

Solution: reverse the order of these destructors.
