### PR TITLE
Problem: class config properties are poorly named

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,15 @@ The zproto_server_c.gsl code generator outputs a single .h file called an *engin
 
 The server is a "actor" built on the CZMQ/zactor class. CZMQ zactors use a simple, consistent API based on message passing:
 
-    zactor_t *server = zactor_new (zpipes_server, "myserver");
-    zstr_sendx (server, "SET", "server/animate", verbose? "1": "0", NULL);
-    zstr_sendx (server, "BIND", "ipc://@/zpipes/local", NULL);
+    zactor_t *server = zactor_new (some_server, "myserver");
+    zstr_send (server, "VERBOSE");
+    zstr_sendx (server, "BIND", endpoint, NULL);
     ...
     zactor_destroy (&server);
 
 Where "myserver" is used in logging. Note that a zactor is effectively a background thread with a socket API, and you can pass zactor_t instances to all CZMQ message passing methods. The generated zactor accepts these messages:
 
+    VERBOSE
     CONFIGURE configfile
     SET configpath value
     BIND localendpoint
@@ -125,8 +126,11 @@ Your input to the code generator is two XML files (without schemas, DTDs, entity
     <class
         name = "hello_server"
         title = "Hello server"
-        proto = "hello_msg"
         script = "zproto_server_c"
+        protocol_class = "hello_msg"
+        package_dir = "../include"
+        source_dir = "."
+        project_header = "hello.h"
         >
         A Hello, World server
 

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -10,7 +10,7 @@ expand_headers ()
 generate_bnf ()
 set_defaults ()
 .endtemplate
-.output "$(class.header)/$(class.name).h"
+.output "$(class.package_dir)/$(class.name).h"
 /*  =========================================================================
     $(class.name) - $(class.title:)
     
@@ -72,45 +72,45 @@ typedef struct _$(class.name)_t $(class.name)_t;
 
 //  @interface
 //  Create a new $(class.name)
-$(CLASS.EXPORT)$(class.name)_t *
+$(CLASS.EXPORT_MACRO)$(class.name)_t *
     $(class.name)_new (int id);
 
 //  Destroy the $(class.name)
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_destroy ($(class.name)_t **self_p);
 
 //  Parse a $(class.name) from zmsg_t. Returns a new object, or NULL if
 //  the message could not be parsed, or was NULL. Destroys msg and 
 //  nullifies the msg reference.
-$(CLASS.EXPORT)$(class.name)_t *
+$(CLASS.EXPORT_MACRO)$(class.name)_t *
     $(class.name)_decode (zmsg_t **msg_p);
 
 //  Encode $(class.name) into zmsg and destroy it. Returns a newly created
 //  object or NULL if error. Use when not in control of sending the message.
-$(CLASS.EXPORT)zmsg_t *
+$(CLASS.EXPORT_MACRO)zmsg_t *
     $(class.name)_encode ($(class.name)_t **self_p);
 
 //  Receive and parse a $(class.name) from the socket. Returns new object, 
 //  or NULL if error. Will block if there's no message waiting.
-$(CLASS.EXPORT)$(class.name)_t *
+$(CLASS.EXPORT_MACRO)$(class.name)_t *
     $(class.name)_recv (void *input);
 
 //  Receive and parse a $(class.name) from the socket. Returns new object, 
 //  or NULL either if there was no input waiting, or the recv was interrupted.
-$(CLASS.EXPORT)$(class.name)_t *
+$(CLASS.EXPORT_MACRO)$(class.name)_t *
     $(class.name)_recv_nowait (void *input);
 
 //  Send the $(class.name) to the output, and destroy it
-$(CLASS.EXPORT)int
+$(CLASS.EXPORT_MACRO)int
     $(class.name)_send ($(class.name)_t **self_p, void *output);
 
 //  Send the $(class.name) to the output, and do not destroy it
-$(CLASS.EXPORT)int
+$(CLASS.EXPORT_MACRO)int
     $(class.name)_send_again ($(class.name)_t *self, void *output);
 
 .for message
 //  Encode the $(message.NAME) 
-$(CLASS.EXPORT)zmsg_t *
+$(CLASS.EXPORT_MACRO)zmsg_t *
     $(class.name)_encode_$(name) (
 .for field where !defined (value)
 .   if !first ()
@@ -139,7 +139,7 @@ $(CLASS.EXPORT)zmsg_t *
 .for message
 //  Send the $(message.NAME) to the output in one step
 //  WARNING, this call will fail if output is of type ZMQ_ROUTER.
-$(CLASS.EXPORT)int
+$(CLASS.EXPORT_MACRO)int
     $(class.name)_send_$(name) (void *output\
 .for field where !defined (value)
 ,
@@ -161,103 +161,103 @@ $(CLASS.EXPORT)int
     
 .endfor
 //  Duplicate the $(class.name) message
-$(CLASS.EXPORT)$(class.name)_t *
+$(CLASS.EXPORT_MACRO)$(class.name)_t *
     $(class.name)_dup ($(class.name)_t *self);
 
 //  Print contents of message to stdout
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_print ($(class.name)_t *self);
 
 //  Get/set the message routing id
-$(CLASS.EXPORT)zframe_t *
+$(CLASS.EXPORT_MACRO)zframe_t *
     $(class.name)_routing_id ($(class.name)_t *self);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_routing_id ($(class.name)_t *self, zframe_t *routing_id);
 
 //  Get the $(class.name) id and printable command
-$(CLASS.EXPORT)int
+$(CLASS.EXPORT_MACRO)int
     $(class.name)_id ($(class.name)_t *self);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_id ($(class.name)_t *self, int id);
-$(CLASS.EXPORT)const char *
+$(CLASS.EXPORT_MACRO)const char *
     $(class.name)_command ($(class.name)_t *self);
 
 .for class.field where !defined (value)
 .   if type = "number"
 //  Get/set the $(name) field
-$(CLASS.EXPORT)$(ctype)
+$(CLASS.EXPORT_MACRO)$(ctype)
     $(class.name)_$(name) ($(class.name)_t *self);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_$(name) ($(class.name)_t *self, $(ctype) $(name));
 .#
 .   elsif type = "octets"
 //  Get/set the $(name) field
-$(CLASS.EXPORT)byte *
+$(CLASS.EXPORT_MACRO)byte *
     $(class.name)_$(name) ($(class.name)_t *self);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_$(name) ($(class.name)_t *self, byte *$(name));
 .#
 .   elsif type = "string" | type = "longstr"
 //  Get/set the $(name) field
-$(CLASS.EXPORT)const char *
+$(CLASS.EXPORT_MACRO)const char *
     $(class.name)_$(name) ($(class.name)_t *self);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_$(name) ($(class.name)_t *self, const char *format, ...);
 .#
 .   elsif type = "strings"
 //  Get/set the $(name) field
-$(CLASS.EXPORT)zlist_t *
+$(CLASS.EXPORT_MACRO)zlist_t *
     $(class.name)_$(name) ($(class.name)_t *self);
 //  Get the $(name) field and transfer ownership to caller
-$(CLASS.EXPORT)zlist_t *
+$(CLASS.EXPORT_MACRO)zlist_t *
     $(class.name)_get_$(name) ($(class.name)_t *self);
 //  Set the $(name) field, transferring ownership from caller
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_$(name) ($(class.name)_t *self, zlist_t **$(name)_p);
 
 //  Iterate through the $(name) field, and append a $(name) value
-$(CLASS.EXPORT)const char *
+$(CLASS.EXPORT_MACRO)const char *
     $(class.name)_$(name)_first ($(class.name)_t *self);
-$(CLASS.EXPORT)const char *
+$(CLASS.EXPORT_MACRO)const char *
     $(class.name)_$(name)_next ($(class.name)_t *self);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_$(name)_append ($(class.name)_t *self, const char *format, ...);
-$(CLASS.EXPORT)size_t
+$(CLASS.EXPORT_MACRO)size_t
     $(class.name)_$(name)_size ($(class.name)_t *self);
 .#
 .   elsif type = "dictionary"
 //  Get/set the $(name) field
-$(CLASS.EXPORT)zhash_t *
+$(CLASS.EXPORT_MACRO)zhash_t *
     $(class.name)_$(name) ($(class.name)_t *self);
 //  Get the $(name) field and transfer ownership to caller
-$(CLASS.EXPORT)zhash_t *
+$(CLASS.EXPORT_MACRO)zhash_t *
     $(class.name)_get_$(name) ($(class.name)_t *self);
 //  Set the $(name) field, transferring ownership from caller
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_$(name) ($(class.name)_t *self, zhash_t **$(name)_p);
     
 //  Get/set a value in the $(name) dictionary
-$(CLASS.EXPORT)const char *
+$(CLASS.EXPORT_MACRO)const char *
     $(class.name)_$(name)_string ($(class.name)_t *self,
         const char *key, const char *default_value);
-$(CLASS.EXPORT)uint64_t
+$(CLASS.EXPORT_MACRO)uint64_t
     $(class.name)_$(name)_number ($(class.name)_t *self,
         const char *key, uint64_t default_value);
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_$(name)_insert ($(class.name)_t *self,
         const char *key, const char *format, ...);
-$(CLASS.EXPORT)size_t
+$(CLASS.EXPORT_MACRO)size_t
     $(class.name)_$(name)_size ($(class.name)_t *self);
 .#
 .   elsif type = "chunk" | type = "frame" | type = "uuid" | type = "msg"
 //  Get a copy of the $(name) field
-$(CLASS.EXPORT)z$(type)_t *
+$(CLASS.EXPORT_MACRO)z$(type)_t *
     $(class.name)_$(name) ($(class.name)_t *self);
 //  Get the $(name) field and transfer ownership to caller
-$(CLASS.EXPORT)z$(type)_t *
+$(CLASS.EXPORT_MACRO)z$(type)_t *
     $(class.name)_get_$(name) ($(class.name)_t *self);
 //  Set the $(name) field, transferring ownership from caller
-$(CLASS.EXPORT)void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_set_$(name) ($(class.name)_t *self, z$(type)_t **$(type)_p);
 .#
 .   else
@@ -266,7 +266,7 @@ $(CLASS.EXPORT)void
 
 .endfor
 //  Self test of this class
-$(CLASS.EXPORT)int
+$(CLASS.EXPORT_MACRO)int
     $(class.name)_test (bool verbose);
 //  @end
 
@@ -278,7 +278,7 @@ $(CLASS.EXPORT)int
 #endif
 
 #endif
-.output "$(class.source)/$(class.name).c"
+.output "$(class.source_dir)/$(class.name).c"
 /*  =========================================================================
     $(class.name) - $(class.title:)
 
@@ -307,10 +307,10 @@ $(CLASS.EXPORT)int
 @end
 */
 
-.if defined (class.include)
-#include "$(class.include)"
+.if defined (class.project_header)
+#include "$(class.project_header)"
 .endif
-#include "$(class.header)/$(class.name).h"
+#include "$(class.package_dir)/$(class.name).h"
 
 //  Structure of our class
 

--- a/src/zproto_example.xml
+++ b/src/zproto_example.xml
@@ -3,6 +3,8 @@
     signature = "0"
     title = "zproto example protocol"
     script = "zproto_codec_c"
+    package_dir = "../include"
+    source_dir = "."
     >
 This is an example protocol designed to teach you how this stuff works.
 

--- a/src/zproto_lib.gsl
+++ b/src/zproto_lib.gsl
@@ -26,11 +26,12 @@ function set_defaults ()
     resolve_types ()
     
     class.signature ?= 0
-    class.header ?= "../include"
-    class.source ?= "."
-    class.export ?= ""
-    if class.export <> ""
-        class.export += " "
+    class.package_dir ?= "../include"
+    class.source_dir ?= "."
+    
+    class.export_macro ?= ""
+    if class.export_macro <> ""
+        class.export_macro += " "
     endif
 
     for message

--- a/src/zproto_lib_go.gsl
+++ b/src/zproto_lib_go.gsl
@@ -28,8 +28,8 @@ function set_defaults ()
     resolve_types ()
     
     class.signature ?= 0
-    class.header ?= "go"
-    class.source ?= "."
+    class.package_dir ?= "go"
+    class.source_dir ?= "."
 
     for message
         message.name = "$(message.name:c)"
@@ -109,7 +109,7 @@ endfunction
 
 function go_package_path ()
     my.name = string.replace(class.name, "_|/")
-    my.path = directory.resolve(class.header + "/" + my.name)
+    my.path = directory.resolve(class.package_dir + "/" + my.name)
     directory.create(my.path)
     return my.path
 endfunction

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -9,7 +9,8 @@ resolve_includes ()
 set_defaults ()
 
 #   Load message structures for this engine
-global.proto = xml.load_file (class.proto + ".xml")
+global.proto = xml.load_file (class.protocol_class + ".xml")
+class.proto = class.protocol_class
 
 #   Lowercase state/event/action names
 for class.state
@@ -74,7 +75,7 @@ endfor
 
 .endtemplate
 .#  This is the API for the server
-.output "$(class.header)/$(class.name).h"
+.output "$(class.package_dir)/$(class.name).h"
 /*  =========================================================================
     $(class.name) - $(class.title:)
 
@@ -114,7 +115,7 @@ extern "C" {
 //  
 //  Enable verbose logging of commands and activity:
 //
-//      zstr_send (ca, "VERBOSE");
+//      zstr_send (server, "VERBOSE");
 //
 //  Bind $(class.title) to specified endpoint. TCP endpoints may specify
 //  the port number as "*" to aquire an ephemeral port:
@@ -148,11 +149,11 @@ extern "C" {
 //
 //  This is the $(class.name) constructor as a zactor_fn:
 //
-CZMQ_EXPORT void
+$(CLASS.EXPORT_MACRO)void
     $(class.name) (zsock_t *pipe, void *args);
 
 //  Self test of this class
-CZMQ_EXPORT void
+$(CLASS.EXPORT_MACRO)void
     $(class.name)_test (bool verbose);
 //  @end
 
@@ -995,9 +996,12 @@ $(class.name) (zsock_t *pipe, void *args)
 @end
 */
 
-#include <czmq.h>
-#include "../include/$(class.proto).h"
-#include "../include/$(class.name).h"
+.if defined (class.project_header)
+#include "$(class.project_header)"
+.endif
+//  TODO: Change these to match your project's needs
+#include "$(class.package_dir)/$(class.protocol_class).h"
+#include "$(class.package_dir)/$(class.name).h"
 
 //  ---------------------------------------------------------------------------
 //  Forward declarations for the two main classes we use here
@@ -1014,7 +1018,7 @@ struct _server_t {
     zsock_t *pipe;              //  Actor pipe back to caller
     zconfig_t *config;          //  Current loaded configuration
     
-    //  Add any properties you need here
+    //  TODO: Add any properties you need here
 };
 
 //  ---------------------------------------------------------------------------
@@ -1028,7 +1032,7 @@ struct _client_t {
     $(proto)_t *request;        //  Last received request
     $(proto)_t *reply;          //  Reply to send out, if any
 
-    //  These properties are specific for this application
+    //  TODO: Add specific properties for your application
 };
 
 //  Include the generated server engine


### PR DESCRIPTION
Solution:
- class.header -> class.package_dir
- class.source -> class.source_dir
- class.include -> class.project_header
- class.proto -> class.protocol_class
- class.export -> class.export_macro

This breaks existing models, sorry. The new names are nicer though.
