### PR TITLE
Backport casting fix for MSVC compilation from zyre

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -707,7 +707,7 @@ $(class.name)_encode ($(class.name)_t **self_p)
                 //  Add up size of dictionary contents
                 char *item = (char *) zhash_first (self->$(name));
                 while (item) {
-                    self->$(name)_bytes += 1 + strlen (zhash_cursor (self->$(name)));
+                    self->$(name)_bytes += 1 + strlen ((const char *) zhash_cursor (self->$(name)));
                     self->$(name)_bytes += 4 + strlen (item);
                     item = (char *) zhash_next (self->$(name));
                 }
@@ -781,7 +781,7 @@ $(class.name)_encode ($(class.name)_t **self_p)
                 PUT_NUMBER4 (zhash_size (self->$(name)));
                 char *item = (char *) zhash_first (self->$(name));
                 while (item) {
-                    PUT_STRING (zhash_cursor (self->$(name)));
+                    PUT_STRING ((const char *) zhash_cursor ((zhash_t *) self->$(name)));
                     PUT_LONGSTR (item);
                     item = (char *) zhash_next (self->$(name));
                 }


### PR DESCRIPTION
As discussed in https://github.com/zeromq/zyre/pull/243
