### PR TITLE
Problem: client timeout handling not working

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -311,6 +311,10 @@ static void
     s_client_execute (s_client_t *self, event_t event);
 static int
     s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument);
+.if count (class.event, name = "expired")
+static int
+    s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument);
+.endif
 static void
     s_satisfy_pedantic_compilers (void);
 .for class.prototype
@@ -419,11 +423,16 @@ engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
 //  The state machine must handle the "expired" event.
 
 static void
-engine_set_timeout (client_t *client, int timeout)
+engine_set_timeout (client_t *client, size_t timeout)
 {
     if (client) {
         s_client_t *self = (s_client_t *) client;
         self->timeout = timeout;
+.if count (class.event, name = "expired")
+        if (self->timeout)
+            self->expiry_timer = zloop_timer (
+                self->loop, self->timeout, 1, s_client_handle_timeout, self);
+.endif
     }
 }
 

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -802,7 +802,7 @@ s_server_apply_config (s_server_t *self)
         if (streq (zconfig_name (section), "bind")) {
             char *endpoint = zconfig_resolve (section, "endpoint", "?");
             if (zsock_bind (self->router, "%s", endpoint) == -1)
-                zsys_warning ("could not bind to %s", endpoint);
+                zsys_warning ("could not bind to %s (%s)", endpoint, zmq_strerror (zmq_errno ()));
         }
         section = zconfig_next (section);
     }


### PR DESCRIPTION
Solution: set-up timer immediately, not only when getting protocol
command.

Also, improved documentation on how to do client/server connection
state. It's not trivial to get right.
