### PR TITLE
Problem: codec headers reffer to czmq types

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -63,6 +63,8 @@ set_defaults ()
 #define $(CLASS.NAME)_$(FIELD.NAME)_SIZE    $(size)
 .endfor
 
+#include "czmq.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Solution: include czmq.h in codec's header file to have zmsg_t et all
resolved
