### PR TITLE
Problem: unconditionally using "czmq.h" and never considering the library

### DIFF
--- a/include/zproto_example.h
+++ b/include/zproto_example.h
@@ -84,6 +84,8 @@
 #define ZPROTO_EXAMPLE_TYPES                4
 #define ZPROTO_EXAMPLE_FLAGS_SIZE           4
 
+#include <czmq.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -63,7 +63,11 @@ set_defaults ()
 #define $(CLASS.NAME)_$(FIELD.NAME)_SIZE    $(size)
 .endfor
 
+.if file.exists ("../include/czmq.h")
 #include "czmq.h"
+.else
+#include <czmq.h>
+.endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Solution: check if "czmq.h" exists in projects context otherwise use library.
