### PR TITLE
Problem: generates duplicate typedefs with zproject

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -182,7 +182,10 @@ extern "C" {
 #endif
 
 //  Opaque class structure
+#ifndef $(CLASS.NAME)_T_DEFINED
 typedef struct _$(class.name)_t $(class.name)_t;
+#define $(CLASS.NAME)_T_DEFINED
+#endif
 
 //  @interface
 //  Create a new $(class.name)

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -74,7 +74,10 @@ extern "C" {
 #endif
 
 //  Opaque class structure
+#ifndef $(CLASS.NAME)_T_DEFINED
 typedef struct _$(class.name)_t $(class.name)_t;
+#define $(CLASS.NAME)_T_DEFINED
+#endif
 
 //  @interface
 //  Create a new $(class.name)


### PR DESCRIPTION
Solution: guard typedef generation against zproject typedefs.
