### PR TITLE
Problem: can't specify where to send Java and Clojure output

### DIFF
--- a/src/zproto_codec_clj.gsl
+++ b/src/zproto_codec_clj.gsl
@@ -7,10 +7,10 @@
 .global.ClassName = java_class_name($(class.name))
 .global.namespace = "org.zproto"
 .global.name_path = "org/zproto"
-.global.java_source_path = "main/java"
-.global.source_path = "main/clojure/src"
-.global.test_path = "main/clojure/test"
-
+.global.root_path ?= switches.root_path? "main"
+.global.java_source_path = "$(root_path)/java"
+.global.source_path = "$(root_path)/clojure/src"
+.global.test_path = "$(root_path)/clojure/test"
 .output "project.clj"
 ;;  =========================================================================
 ;;    $(class.title:)

--- a/src/zproto_codec_java.gsl
+++ b/src/zproto_codec_java.gsl
@@ -14,8 +14,9 @@ set_defaults ()
 .global.ClassName = java_class_name($(class.name))
 .global.namespace = "org.zproto"
 .global.name_path = "org/zproto"
-.directory.create ("main/java/$(name_path)")
-.output "main/java/$(name_path)/$(ClassName).java"
+.global.root_path ?= switches.root_path? "main"
+.directory.create ("$(root_path)/java/$(name_path)")
+.output "$(root_path)/java/$(name_path)/$(ClassName).java"
 /*  =========================================================================
     $(ClassName) - $(class.title:)
 
@@ -926,7 +927,7 @@ public class $(ClassName) implements java.io.Closeable
 .endfor
 }
 
-.output "main/java/$(name_path)/Test$(ClassName).java"
+.output "$(root_path)/java/$(name_path)/Test$(ClassName).java"
 package $(namespace);
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
Solution: add -root_path:xxx option, so from src, you can set this
to -root_path:../main.

It's still unclear where the best place is for model files in a
multilanguage project. To be tweaked. For now they're in src.
