### PR TITLE
Problem: recv needs to operate on actual ZMQ socket.

### DIFF
--- a/src/zproto_codec_clj.gsl
+++ b/src/zproto_codec_clj.gsl
@@ -114,7 +114,7 @@
                  (zmq/bind endpoint))]
     (->$(ClassName)Socket socket)))
 
-(defn recv [socket]
+(defn recv [{:keys [socket]}]
   ($(ClassName)/recv socket))
 .directory.create ("$(test_path)/$(name_path)")
 .output "$(test_path)/$(name_path)/$(class.name)_test.clj"


### PR DESCRIPTION
Solution: use underlying ZMQ socket instead of client-/server socket
