### PR TITLE
Problem: default leiningen project license reference is confusing and not needed

### DIFF
--- a/src/zproto_codec_clj.gsl
+++ b/src/zproto_codec_clj.gsl
@@ -11,6 +11,7 @@
 .global.java_source_path = "$(root_path)/java"
 .global.source_path = "$(root_path)/clojure/src"
 .global.test_path = "$(root_path)/clojure/test"
+.if !file.exists ("../project.clj")
 .output "../project.clj"
 ;;  =========================================================================
 ;;    $(class.title:)
@@ -40,6 +41,7 @@
                  [org.zeromq/cljzmq "0.1.4" :exclusions [jzmq]]
                  [org.zeromq/jeromq "0.3.4"]])
 .directory.create ("$(source_path)/$(name_path)")
+.endif
 .output "$(source_path)/$(name_path)/$(class.name).clj"
 ;;  =========================================================================
 ;;    $(ClassName) - $(class.title:)


### PR DESCRIPTION
Solution: remove boilerplate lines from template (actual project license is mentioned above in source file).
