### PR TITLE
Problem: recv method encounters exceptions when called on socket with non-default receive timeout

### DIFF
--- a/src/zproto_codec_java.gsl
+++ b/src/zproto_codec_java.gsl
@@ -265,6 +265,8 @@ public class $(ClassName) implements java.io.Closeable
                     self.routingId = ZFrame.recvFrame (input);
                     if (self.routingId == null)
                         return null;         //  Interrupted
+                    if (!self.routingId.hasData())
+                        return null;         //  Empty Frame (eg recv-timeout)
                     if (!input.hasReceiveMore ())
                         throw new IllegalArgumentException ();
                 }


### PR DESCRIPTION
Solution: when encountering an empty (non-null) routing-id ZFrame, return null instead of failing with exception later at the hasReceiveMore() check.
