### PR TITLE
Problem: cannot use inproc transport when creating sockets.

### DIFF
--- a/src/zproto_codec_clj.gsl
+++ b/src/zproto_codec_clj.gsl
@@ -115,19 +115,23 @@
 .endfor
 )
 
-(defn client-socket [endpoint]
-  (let [context (zmq/context)
-        socket (doto (zmq/socket context :dealer)
-                 (zmq/set-receive-timeout 1000)
-                 (zmq/connect endpoint))]
-    (->$(ClassName)Socket socket)))
+(defn client-socket
+  ([endpoint context]
+    (let [socket (doto (zmq/socket context :dealer)
+                   (zmq/set-receive-timeout 1000)
+                   (zmq/connect endpoint))]
+      (->$(ClassName)Socket socket)))
+  ([endpoint]
+    (client-socket endpoint (zmq/context))))
 
-(defn server-socket [endpoint]
-  (let [context (zmq/context)
-        socket (doto (zmq/socket context :router)
-                 (zmq/set-receive-timeout 1000)
-                 (zmq/bind endpoint))]
-    (->$(ClassName)Socket socket)))
+(defn server-socket
+  ([endpoint context]
+    (let [socket (doto (zmq/socket context :router)
+                   (zmq/set-receive-timeout 1000)
+                   (zmq/bind endpoint))]
+       (->$(ClassName)Socket socket)))
+  ([endpoint]
+    (server-socket endpoint (zmq/context))))
 
 (defn recv [{:keys [socket]}]
   ($(ClassName)/recv socket))


### PR DESCRIPTION
Solution: allow zmq context as param when creating sockets.
