### PR TITLE
Problem: Server class header uses wrong value for title

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -80,7 +80,7 @@ endfor
 .#  This is the API for the server
 .output "$(class.package_dir)/$(class.name).h"
 /*  =========================================================================
-    $(class.name) - $(class.name:)
+    $(class.name) - $(class.title:)
 
     ** WARNING *************************************************************
     THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose


### PR DESCRIPTION
Solution: Use class.title for server class title
