### PR TITLE
Part of an ongoing cleanup of server/client codecs

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -225,37 +225,6 @@ s_event_name [] = {
 .endfor
 };
 
-static bool
-s_event_matrix [$(count (class.state)) + 1][$(count (class.event)) + 1] = {
-    { 0, \
-.for class.event
-0, \
-.endfor
-}, // (NONE)
-.for class.state
-    { 0, \
-.   if count (event, event.name = "*")
-.       for class.event
-1, \
-.       endfor
-.   else
-.       for class.event as class_event
-.           if count (state.event, event.name = class_event.name)
-1, \
-.           else
-0, \
-.           endif
-.       endfor
-.   endif
-}\
-.   if last()
-  // $(state.name)_state
-.   else
-, // $(state.name)_state
-.   endif
-.endfor
-};
-
 //  ---------------------------------------------------------------------------
 //  Context for the whole server task. This embeds the application-level
 //  server context at its start (the entire structure, not a reference),


### PR DESCRIPTION
There is one breaking change, the removal of the mailbox functionality. This was honestly too confusing and if apps want to do this, they can do it themselves. The state machine should be explicit about what commands it accepts or rejects in any state.
