### PR TITLE
Problem: C codec doesn't account for case where string field is set to its current value

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -965,6 +965,9 @@ void
 $(class.name)_set_$(name) ($(class.name)_t *self, const char *value)
 {
     assert (self);
+    assert (value);
+    if (value == self->$(name))
+        return;
     strncpy (self->$(name), value, 255);
     self->$(name) [255] = 0;
 }
@@ -984,6 +987,7 @@ void
 $(class.name)_set_$(name) ($(class.name)_t *self, const char *value)
 {
     assert (self);
+    assert (value);
     zstr_free (&self->$(name));
     self->$(name) = strdup (value);
 }


### PR DESCRIPTION
e.g.

``` c
mymsg_set_mystring (mymsg, mymsg_mystring (mymsg));
```

This causes the valgrind error "Source and destination overlap in strncpy".
It is also extra work because no copy is necessary.

Although this seems silly, it may come up in in some cases where, for example,
the processing of a request and forming of a reply is separated by several layers
of logic that make tracking whether the field has changed between request and
reply more trouble than just setting it again.

Solution: Don't perform the copy if the (const char*) pointer value is identical.

Incidental: Add assert guards for when the pointer is NULL.
