### PR TITLE
Problem: Client blocks on destroy if no messages pending on dealer

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -671,7 +671,7 @@ s_client_handle_cmdpipe (zloop_t *loop, zsock_t *reader, void *argument)
     else
     if (streq (method, "$TERM")) {
         self->terminated = true;    //  Shutdown the engine
-        return -1;
+        goto terminated;
     }
 .for class.method where immediate = 0
     else
@@ -688,7 +688,7 @@ s_client_handle_cmdpipe (zloop_t *loop, zsock_t *reader, void *argument)
 .   endif
         s_client_execute (self, $(name:c)_event);
         if (self->terminated)
-            return -1;
+            goto terminated;
     }
 .endfor
     //  Cleanup pipe if any argument frames are still waiting to be eaten
@@ -700,6 +700,10 @@ s_client_handle_cmdpipe (zloop_t *loop, zsock_t *reader, void *argument)
     }
     zstr_free (&method);
     return 0;
+    
+    terminated:
+    zstr_free (&method);
+    return -1;
 }
 
 


### PR DESCRIPTION
Solution: return -1 to interrupt zloop on $TERM

@hintjens 
Please look this over and see if I just missed some other mechanism already in place to do this.  The code where this fails is actually the client test generated by zproto:

``` c
    //  @selftest
    zactor_t *client = zactor_new (myclientclass, NULL);
    if (verbose)
        zstr_send (client, "VERBOSE");
    zactor_destroy (&client); // this line blocks forever
    //  @end
```

The marked line blocks "forever" because the `s_client_handle_cmdpipe` ends and there is no readable socket to trigger the poll of the zloop again (unless a message arrives on the dealer).

EDIT: Added another commit patching up a memory leak in this same area
