### PR TITLE
Problem: no generated stub for implementation of clojure server backend (actions)

### DIFF
--- a/src/zproto_codec_clj.gsl
+++ b/src/zproto_codec_clj.gsl
@@ -8,41 +8,10 @@
 .global.namespace = "org.zproto"
 .global.name_path = "org/zproto"
 .global.topdir ?= "$(switches.topdir)/main" ? "main"
-.global.java_source_path = "$(topdir)/java"
 .global.source_path = "$(topdir)/clojure/src"
 .global.test_path = "$(topdir)/clojure/test"
 .directory.create ("$(source_path)/$(name_path)")
 .directory.create ("$(test_path)/$(name_path)")
-.if !file.exists ("../project.clj")
-.output "../project.clj"
-;;  =========================================================================
-;;    $(class.title:)
-;;
-;;    ** WARNING *************************************************************
-;;    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
-;;    your changes at the next build cycle. This is great for temporary printf
-;;    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
-;;    for commits are:
-;;
-;;    * The XML model used for this code generation: $(filename)
-;;    * The code generation script that built this file: $(script)
-;;    ************************************************************************
-.   for class.license
-;;    $(string.trim (license.):block                                          )
-.   endfor
-;;    =========================================================================
-(defproject $(clj_name(class.title)) "0.1.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :java-source-paths ["$(string.defix (java_source_path, "../"))"]
-  :source-paths ["$(string.defix (source_path, "../"))"]
-  :test-paths ["$(string.defix (test_path, "../"))"]
-  :prep-tasks ["javac"]
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [junit/junit "4.11"]
-                 [org.zeromq/cljzmq "0.1.4" :exclusions [jzmq]]
-                 [org.zeromq/jeromq "0.3.4"]])
-.endif
 .output "$(source_path)/$(name_path)/$(class.name).clj"
 ;;  =========================================================================
 ;;    $(ClassName) - $(class.title:)

--- a/src/zproto_server_clj.gsl
+++ b/src/zproto_server_clj.gsl
@@ -11,8 +11,9 @@ global.namespace = "org.zproto"
 global.name_path = "org/zproto"
 global.topdir ?= "$(switches.topdir)/main" ? "main"
 global.root_path ?= switches.root_path? "main"
+global.java_source_path = "$(topdir)/java"
 global.source_path = "$(topdir)/clojure/src"
-
+global.test_path = "$(topdir)/clojure/test"
 #   Load message structures for this engine
 global.proto = xml.load_file (class.protocol_class + ".xml")
 class.proto = class.protocol_class
@@ -229,3 +230,66 @@ terminate \
       (if (not (.isInterrupted (Thread/currentThread)))
         (recur)
         (println "Server shutdown")))))
+.source_file = "$(source_path)/$(name_path)/$(class.name)_impl.clj"
+.if !file.exists (source_file)
+.output source_file
+;;  =========================================================================
+;;    $(class.name:) implementation
+;;
+.   for class.license
+;;    $(string.trim (license.):block                                          )
+.   endfor
+;;  =========================================================================
+(ns $(namespace).$(clj_name (class.name))-impl
+  (:require [$(namespace).$(clj_name (class.name)) :as server]
+            [org.zproto.$(clj_protocol_class ()) :as m]))
+
+(def backend
+  (reify server/$(java_class_name (class.name))Backend\
+.for class.action
+. if name <> "send" & name <> "terminate"
+
+    ($(clj_name (name)) [this msg\
+. for action.param
+ $(clj_name(name))\
+. endfor
+])\
+. endif
+.endfor
+))
+.endif
+
+(defn -main [& [endpoint]]
+  (println (format "starting up $(class.name) at %s" endpoint))
+  (server/server-loop (m/server-socket endpoint) backend))
+.if !file.exists ("../project.clj")
+.output "../project.clj"
+;;  =========================================================================
+;;    $(class.title:)
+;;
+;;    ** WARNING *************************************************************
+;;    THIS SOURCE FILE IS 100% GENERATED. If you edit this file, you will lose
+;;    your changes at the next build cycle. This is great for temporary printf
+;;    statements. DO NOT MAKE ANY CHANGES YOU WISH TO KEEP. The correct places
+;;    for commits are:
+;;
+;;    * The XML model used for this code generation: $(filename)
+;;    * The code generation script that built this file: $(script)
+;;    ************************************************************************
+.   for class.license
+;;    $(string.trim (license.):block                                          )
+.   endfor
+;;    =========================================================================
+(defproject $(clj_name(class.title)) "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :java-source-paths ["$(string.defix (java_source_path, "../"))"]
+  :source-paths ["$(string.defix (source_path, "../"))"]
+  :test-paths ["$(string.defix (test_path, "../"))"]
+  :prep-tasks ["javac"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [junit/junit "4.11"]
+                 [org.zeromq/cljzmq "0.1.4" :exclusions [jzmq]]
+                 [org.zeromq/jeromq "0.3.4"]]
+  :main $(namespace).$(clj_name (class.name))-impl)
+.endif


### PR DESCRIPTION
Solution: add template for server implementation file that is generated once only. add main declaration to project.clj template that will use the backend defined in the impl file to spin up a server. server endpoint is given as command-line arg.
