### PR TITLE
Removed reference to nonexistent server unique_id

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -713,7 +713,7 @@ s_client_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
             return -1;              //  Interrupted; exit zloop
 
 .if switches.trace ?= 1
-        zsys_debug ("%d: Server message", self->unique_id);
+        zsys_debug ("Server message");
         $(proto)_print (self->message);
 .endif
 .if count (class.event, name = "expired")


### PR DESCRIPTION
Problem: When generating the client code with the trace option
turned on there is a reference to the server's unique_id which
does not exist.

Solution: Removed the reference.
