### PR TITLE
Problem: encoding message with string uses printf

### DIFF
--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -1035,8 +1035,10 @@ $(class.name)_encode_$(name) (
 {
     $(class.name)_t *self = $(class.name)_new ($(class.NAME)_$(NAME));
 .for field where !defined (value)
-.   if type = "number" | type = "octets" | type = "string" | type = "longstr"
+.   if type = "number" | type = "octets"
     $(class.name)_set_$(name) (self, $(name));
+.   elsif type = "string" | type = "longstr"
+    $(class.name)_set_$(name) (self, "%s", $(name));
 .   elsif type = "strings"
     zlist_t *$(name)_copy = zlist_dup ($(name));
     $(class.name)_set_$(name) (self, &$(name)_copy);


### PR DESCRIPTION
This might actually have some security implications if people using the
library are not avare of this and missuse _encode function. With _encode
function one can construct whole message in one go. Tricky part is that
if it contains string, there is no way to pass additional argument, so
one would expect that contrary to _set method, string is not passed
through printf function. Contrary is true and thus one can for example
call _encode(1, "%s %s") which will try to access not existing arguments
for printf as encode calls _set function.

Solution: Use _set("%s", str) in _encode.
