### PR TITLE
Problem: Need a non-redundant way to specify transition actions by state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,27 @@ For complex protocols you can collect error handling together using the wildcard
         </event>
     </state>
 
+### Before/After State Actions
+
+As another way to reduce error-prone repetition, it is possible to add actions to be executed for any event that transitions to or from a given state. This is modelled with a before or after element containing one or more action elements inside of a state element. The given actions will be executed only when the state of the machine changes to or from that state (due to an event that has the "next" attribute defined).
+
+    <state name = "active" inherit = "defaults">
+        <before>
+            <action name = "start underlying service" />
+        </before>
+        <event name = "REQUEST">
+            <action name = "store metadata" />
+            <action name = "forward to underlying service" />
+        </event>
+        <event name = "reply from underlying service">
+            <action name = "send" message = "REPLY" />
+            <action name = "clear metadata" />
+        </event>
+        <after>
+            <action name = "stop underlying service" />
+        </after>
+    </state>
+
 ### Client Properties
 
 In your client code, you have a client_t structure. Note that the client_t structure MUST always start with these variables (the msgout and msgin will use whatever protocol name you defined):

--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -50,6 +50,16 @@ for class.state
             copy action to class
         endfor
     endfor
+    for [before]
+        for action where count (class.action, name = -1.name) = 0
+            copy action to class
+        endfor
+    endfor
+    for [after]
+        for action where count (class.action, name = -1.name) = 0
+            copy action to class
+        endfor
+    endfor
 endfor
 
 #   Process super states
@@ -692,9 +702,18 @@ s_protocol_event (s_client_t *self, $(proto)_t *message)
 .           endif
                     }
 .       endfor
+.endmacro
+.macro output_state_change ()
 .       if defined (event.next)
+.           for state.[after]
+.               output_action_body ()
+.           endfor
                     if (!self->exception)
                         self->state = $(next:c)_state;
+.           my.next_state = class->state ("$(name:c)" = "$(event.next:c)")
+.           for my.next_state.[before]
+.               output_action_body ()
+.           endfor
 .       endif
 .endmacro
 
@@ -732,6 +751,7 @@ s_client_execute (s_client_t *self, event_t event)
 .       endif
                 if (self->event == $(name)_event) {
 .       output_action_body ()
+.       output_state_change ()
                 }
 .   endfor
 .   for event where name = "*"
@@ -742,6 +762,7 @@ s_client_execute (s_client_t *self, event_t event)
 .       endif
                     //  Handle unexpected protocol events
 .       output_action_body ()
+.       output_state_change ()
                 }
 .   else
                 else {

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -50,6 +50,16 @@ for class.state
             copy action to class
         endfor
     endfor
+    for [before]
+        for action where count (class.action, name = -1.name) = 0
+            copy action to class
+        endfor
+    endfor
+    for [after]
+        for action where count (class.action, name = -1.name) = 0
+            copy action to class
+        endfor
+    endfor
 endfor
 
 #   Process super states recursively
@@ -583,9 +593,18 @@ s_client_free (void *argument)
 .           endif
                     }
 .       endfor
+.endmacro
+.macro output_state_change ()
 .       if defined (event.next)
+.           for state.[after]
+.               output_action_body ()
+.           endfor
                     if (!self->exception)
                         self->state = $(next:c)_state;
+.           my.next_state = class->state ("$(name:c)" = "$(event.next:c)")
+.           for my.next_state.[before]
+.               output_action_body ()
+.           endfor
 .       endif
 .endmacro
 
@@ -622,6 +641,7 @@ s_client_execute (s_client_t *self, event_t event)
 .       endif
                 if (self->event == $(name)_event) {
 .       output_action_body ()
+.       output_state_change ()
                 }
 .   endfor
 .   for event where name = "*"
@@ -632,6 +652,7 @@ s_client_execute (s_client_t *self, event_t event)
 .       endif
                     //  Handle unexpected protocol events
 .       output_action_body ()
+.       output_state_change ()
                 }
 .   else
                 else {


### PR DESCRIPTION
Solution: Support the `before` and `after` model elements.
Resolves #195.