### PR TITLE
Problem: the generated client bindings do not do any logging for messages with no actions

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -702,6 +702,11 @@ s_protocol_event (s_client_t *self, $(proto)_t *message)
 .           endif
                     }
 .       endfor
+.       if ! count (action)
+			// no action - just logging
+                        if ($(class.name)_verbose)
+                            zsys_debug ("$(class.name):         $ $(name)");
+.       endif
 .endmacro
 .macro output_state_change ()
 .       if defined (event.next)


### PR DESCRIPTION
Solution: add more logging in the GSL code generator