### PR TITLE
Silence "unused" warning from compiler in generated C/C++ code

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -1109,6 +1109,9 @@ $(class.name)_test (bool verbose)
 {
     printf (" * $(class.name): ");
 
+    //  Silence an "unused" warning by "using" the verbose variable
+    if (verbose) {;}
+
     //  @selftest
     //  Simple create/destroy test
     $(class.name)_t *self = $(class.name)_new ();

--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -1539,6 +1539,9 @@ $(class.name)_test (bool verbose)
 {
     printf (" * $(class.name): ");
 
+    //  Silence an "unused" warning by "using" the verbose variable
+    if (verbose) {;}
+
     //  @selftest
     //  Simple create/destroy test
     $(class.name)_t *self = $(class.name)_new (0);


### PR DESCRIPTION
Problem: Generated C++ code causes GCC to complain (-Wunused-variable) about the "bool verbose" in *_test() methods.
Solution: Make up artificial usage for the variable, which might be really used later, to satisfy the compiler.