### PR TITLE
Fields' comments can now be multiline.

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -231,20 +231,27 @@ struct _$(class.name)_t {
     byte *ceiling;                      //  Valid upper limit for read pointer
 .for class.field
 .   if type = "number" & !defined (field.value)
-    $(ctype) $(name);                   //  $(field.?'':)
+    /* $(field.?'':)  */
+    $(ctype) $(name);
 .   elsif type = "octets"
-    byte $(name) [$(size)];             //  $(field.?'':)
+    /* $(field.?'':)  */
+    byte $(name) [$(size)];
 .   elsif type = "string" & !defined (field.value)
-    char $(name) [256];                 //  $(field.?'':)
+    /* $(field.?'':)  */
+    char $(name) [256];
 .   elsif type = "longstr"
-    char *$(name);                      //  $(field.?'':)
+    /* $(field.?'':)  */
+    char *$(name);
 .   elsif type = "strings"
-    zlist_t *$(name);                   //  $(field.?'':)
+    /* $(field.?'':)  */
+    zlist_t *$(name);
 .   elsif type = "hash"
-    zhash_t *$(name);                   //  $(field.?'':)
+    /* $(field.?'':)  */
+    zhash_t *$(name);
     size_t $(name)_bytes;               //  Size of hash content
 .   elsif type = "chunk" | type = "frame" | type = "uuid" | type = "msg"
-    z$(type)_t *$(name);                //  $(field.?'':)
+    /* $(field.?'':)  */
+    z$(type)_t *$(name);
 .   endif
 .endfor
 };


### PR DESCRIPTION
As described in #203 if a field comment was multiline this would
cause the code to not compile.

This was due to comments being started with //.
This commits update the gsl script to write comment with
the /* .. */ syntax instead.

This fixes #203.