### PR TITLE
Problem: zproto client constructor does too much

### DIFF
--- a/doc/zproto_example.txt
+++ b/doc/zproto_example.txt
@@ -311,6 +311,11 @@ EXAMPLE
         assert (zproto_example_flags (self) [0] == 123);
         assert (zproto_example_flags (self) [ZPROTO_EXAMPLE_FLAGS_SIZE - 1] == 123);
         assert (memcmp (zchunk_data (zproto_example_public_key (self)), "Captcha Diem", 12) == 0);
+        zuuid_t *acutal_identifier = zproto_example_identifier (self);
+        assert (zuuid_eq (binary_identifier_dup, zuuid_data (acutal_identifier)));
+        if (instance == 1) {
+            zuuid_destroy (&binary_identifier_dup);
+        }
         assert (zframe_streq (zproto_example_address (self), "Captcha Diem"));
         assert (zmsg_size (zproto_example_content (self)) == 1);
     }

--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -199,12 +199,6 @@ for class.method
     else
         method.return = "0"
     endif
-    if method.name = "constructor"
-        method.args = string.substr (method.args, 2)
-        if method.args = ""
-            method.args = "void"
-        endif
-    endif
 endfor
 
 for class.send
@@ -300,18 +294,12 @@ typedef struct _$(class.name)_t $(class.name)_t;
 #endif
 
 //  @interface
-//  Create a new $(class.name)
-.for class.method where name = "constructor"
-//  $(method.?'No explanation':justify,block%-80s)
-$(CLASS.EXPORT_MACRO)$(class.name)_t *
-    $(class.name)_new ($(args));
-.else
-
+//  Create a new $(class.name), return the reference if successful, or NULL
+//  if construction failed due to lack of available memory.
 $(CLASS.EXPORT_MACRO)$(class.name)_t *
     $(class.name)_new (void);
-.endfor
 
-//  Destroy the $(class.name)
+//  Destroy the $(class.name) and free all memory used by the object.
 $(CLASS.EXPORT_MACRO)void
     $(class.name)_destroy ($(class.name)_t **self_p);
 
@@ -1025,17 +1013,8 @@ $(class.name)_new (void)
     if (self) {
         zsock_t *backend;
         self->msgpipe = zsys_create_pipe (&backend);
-        self->actor = zactor_new ($(class.name), backend);
-.for class.method where name = "constructor"
-        if (self->actor)
-            $(return) = $(class.name)_constructor (self\
-.       for field
-, $(name:c)\
-.       endfor
-);
-        if ($(return) == -1)
-            zactor_destroy (&self->actor);
-.endfor
+        if (self->msgpipe)
+            self->actor = zactor_new ($(class.name), backend);
         if (!self->actor)
             $(class.name)_destroy (&self);
     }


### PR DESCRIPTION
The constructor is used to also connect to servers. This is neat except
that when it fails, the constructor fails, and there is no way to return
status information to the caller.

Solution: constructor should only initialize object. The connect method
should be done seperately.

- Removed support for "constructor" as special method in GSL code
- Removed call to constructor method, in class constructor

Note: this breaks existing client models and code. The fix is simple.
1. rename "constructor" to "connect" in XML model
2. in all calls to xxx_new, remove arguments
3. add second call to xxx_connect, with connection arguments
4. test return code 0/-1 from that method

See Malamute mlm_client as example.

Fixes #208