### PR TITLE
PROBLEM: can't have value of 'export_macro' attribute (of class element)

### DIFF
--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -69,6 +69,10 @@ set_defaults ()
 #include <czmq.h>
 .endif
 
+.if defined (class.export_header)
+#include "$(class.export_header)"
+.endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
expanded using preprocessor macro

SOLUTION: add attribute 'export_header' to element 'class' in which the
macro can be defined.