### PR TITLE
Fix include guards.

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -274,8 +274,8 @@ endfor
     =========================================================================
 */
 
-#ifndef __$(CLASS.NAME)_H_INCLUDED__
-#define __$(CLASS.NAME)_H_INCLUDED__
+#ifndef $(CLASS.NAME)_H_INCLUDED
+#define $(CLASS.NAME)_H_INCLUDED
 
 .if file.exists ("../include/czmq.h")
 #include "czmq.h"

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -43,8 +43,8 @@ set_defaults ()
     =========================================================================
 */
 
-#ifndef __$(CLASS.NAME)_H_INCLUDED__
-#define __$(CLASS.NAME)_H_INCLUDED__
+#ifndef $(CLASS.NAME)_H_INCLUDED
+#define $(CLASS.NAME)_H_INCLUDED
 
 /*  These are the $(class.name) messages:
 .for message

--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -31,8 +31,8 @@ set_defaults ()
     =========================================================================
 */
 
-#ifndef __$(CLASS.NAME)_H_INCLUDED__
-#define __$(CLASS.NAME)_H_INCLUDED__
+#ifndef $(CLASS.NAME)_H_INCLUDED
+#define $(CLASS.NAME)_H_INCLUDED
 
 /*  These are the $(class.name) messages:
 .for message

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -115,8 +115,8 @@ endfor
     =========================================================================
 */
 
-#ifndef __$(CLASS.NAME)_H_INCLUDED__
-#define __$(CLASS.NAME)_H_INCLUDED__
+#ifndef $(CLASS.NAME)_H_INCLUDED
+#define $(CLASS.NAME)_H_INCLUDED
 
 .if file.exists ("../include/czmq.h")
 #include "czmq.h"


### PR DESCRIPTION
The generation of include guards did not fit to [the expected naming convention of the C++ language standard](https://www.securecoding.cert.org/confluence/display/cplusplus/DCL32-CPP.+Do+not+declare+or+define+a+reserved+identifier#DCL32-CPP.Donotdeclareordefineareservedidentifier-NoncompliantCodeExample%28HeaderGuard%29 "Do not use identifiers that are reserved for the compiler implementation.").

This implementation detail can be fixed by deletion of [a few underscores](http://stackoverflow.com/questions/228783/what-are-the-rules-about-using-an-underscore-in-a-c-identifier#answer-228797 "What are the rules about using an underscore in a C++ identifier?").