### PR TITLE
Problem: need integration tests between codecs

### DIFF
--- a/include/zproto_example.h
+++ b/include/zproto_example.h
@@ -35,8 +35,8 @@
     =========================================================================
 */
 
-#ifndef __ZPROTO_EXAMPLE_H_INCLUDED__
-#define __ZPROTO_EXAMPLE_H_INCLUDED__
+#ifndef ZPROTO_EXAMPLE_H_INCLUDED
+#define ZPROTO_EXAMPLE_H_INCLUDED
 
 /*  These are the zproto_example messages:
 

--- a/src/selftest
+++ b/src/selftest
@@ -11,6 +11,15 @@ if [ $? -eq 0 ]; then
     if [ "$1" == "-q" ]; then
         ./zproto_selftest
         exit
+    elif [ "$1" == "-d" ]; then
+        for entry in `./zproto_selftest 2>&1 >/dev/null`
+        do
+            message=`cut -d "-" -f1 <<< "$entry"`
+            digest=`cut -d "-" -f2 <<< "$entry"`
+            sed -i -e "s/\(message.*\"${message}\".*digest\s*=\s*\"\)[^\"]*/\1${digest}/" zproto_example.xml
+        done
+        echo "updated digests in zproto_example.xml"
+        exit
     else
         $VG ./zproto_selftest
     fi

--- a/src/selftest
+++ b/src/selftest
@@ -16,7 +16,16 @@ if [ $? -eq 0 ]; then
         do
             message=`cut -d "-" -f1 <<< "$entry"`
             digest=`cut -d "-" -f2 <<< "$entry"`
-            sed -i -e "s/\(message.*\"${message}\".*digest\s*=\s*\"\)[^\"]*/\1${digest}/" zproto_example.xml
+
+            sed -i "/name\s*=\s*\"${message}\"/{
+                   \$!{ :start
+                      N         # append the next line when not on the last line
+                      s/\(.*digest\s*=\s*\"\)[^\"]*/\1${digest}/
+                      t done    # If replaced successfully goto done otherwise go to next line
+                      b start
+                      :done
+                    }
+                 }" zproto_example.xml
         done
         echo "updated digests in zproto_example.xml"
         exit

--- a/src/zproto_bnf.gsl
+++ b/src/zproto_bnf.gsl
@@ -48,12 +48,12 @@ function generate_bnf
         endif
         for field
             if type = "number"
-                    >    $(name:c)       = number-$(size)        ; $(field.?'':)
+                    >    $(name:c)       = number-$(size)        ; $(string.trim (field.)?'':left)
                     class.use_number_$(size) = 1
             elsif type = "octets"
-                    >    $(name:c)       = $(size)OCTET          ; $(field.?'':)
+                    >    $(name:c)       = $(size)OCTET          ; $(string.trim (field.)?'':left)
             else
-                    >    $(name:c)       = $(type)               ; $(field.?'':)
+                    >    $(name:c)       = $(type)               ; $(string.trim (field.)?'':left)
                     class.use_$(type) = 1
             endif
         endfor
@@ -66,12 +66,12 @@ function generate_bnf
                 >
                 for field
                     if field.type = "number"
-                        >    $(name:c)       = number-$(size)        ; $(field.?'':)
+                        >    $(name:c)       = number-$(size)        ; $(string.trim (field.)?'':left)
                         class.use_number_$(size) = 1
                     elsif field.type = "octets"
-                        >    $(name:c)       = $(size)OCTET          ; $(field.?'':)
+                        >    $(name:c)       = $(size)OCTET          ; $(string.trim (field.)?'':left)
                     else
-                        >    $(name:c)       = $(field.type)         ; $(field.?'':)
+                        >    $(name:c)       = $(field.type)         ; $(string.trim (field.)?'':left)
                         class.use_$(field.type) = 1
                     endif
                 endfor

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -53,12 +53,12 @@ set_defaults ()
 .   for field
 .       if type = "number"
         $(name)             $(type) $(size)\
-                                        $(field.?'':)
+                                        $(string.trim (field.)?'':left)
 .       elsif type = "octets"
         $(name)             $(type) [$(size)]\
-                                        $(field.?'':)
+                                        $(string.trim (field.)?'':left)
 .       else
-        $(name)             $(type)     $(field.?'':)
+        $(name)             $(type)     $(string.trim (field.)?'':left)
 .       endif
 .   endfor
 .endfor
@@ -231,26 +231,26 @@ struct _$(class.name)_t {
     byte *ceiling;                      //  Valid upper limit for read pointer
 .for class.field
 .   if type = "number" & !defined (field.value)
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     $(ctype) $(name);
 .   elsif type = "octets"
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     byte $(name) [$(size)];
 .   elsif type = "string" & !defined (field.value)
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     char $(name) [256];
 .   elsif type = "longstr"
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     char *$(name);
 .   elsif type = "strings"
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     zlist_t *$(name);
 .   elsif type = "hash"
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     zhash_t *$(name);
     size_t $(name)_bytes;               //  Size of hash content
 .   elsif type = "chunk" | type = "frame" | type = "uuid" | type = "msg"
-    /* $(field.?'':)  */
+    // $(string.trim (field.)?name:left,block)
     z$(type)_t *$(name);
 .   endif
 .endfor
@@ -474,7 +474,11 @@ $(class.name)_recv ($(class.name)_t *self, zsock_t *input)
     //  Get and check protocol signature
     self->needle = (byte *) zmq_msg_data (&frame);
     self->ceiling = self->needle + zmq_msg_size (&frame);
+
+.if switches.digest ?= 1
+    zdigest_t * digest = zdigest_new ();
     
+.endif
     uint16_t signature;
     GET_NUMBER2 (signature);
     if (signature != (0xAAA0 | $(class.signature))) {
@@ -489,6 +493,12 @@ $(class.name)_recv ($(class.name)_t *self, zsock_t *input)
     switch (self->id) {
 .for class.message
         case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   if switches.digest ?= 1
+            zdigest_update (digest, (byte *) zmq_msg_data (&frame), zmq_msg_size (&frame));
+            // This is a hacky way of sending digests to the "./selftest -d" script through stderr
+            fprintf(stderr, "$(MESSAGE.NAME)-%s\\n", zdigest_string (digest));
+
+.   endif
 .   for field
 .       if type = "number"
 .           if defined (field.value)
@@ -594,12 +604,18 @@ $(class.name)_recv ($(class.name)_t *self, zsock_t *input)
             goto malformed;
     }
     //  Successful return
+.if switches.digest ?= 1
+    zdigest_destroy (&digest);
+.endif
     zmq_msg_close (&frame);
     return 0;
 
     //  Error returns
     malformed:
         zsys_warning ("$(class.name): $(name) malformed message, fail");
+.if switches.digest ?= 1
+        zdigest_destroy (&digest);
+.endif
         zmq_msg_close (&frame);
         return -1;              //  Invalid message
 }
@@ -1114,7 +1130,10 @@ $(class.name)_set_$(name) ($(class.name)_t *self, z$(type)_t **$(type)_p)
 int
 $(class.name)_test (bool verbose)
 {
-    printf (" * $(class.name): ");
+    printf (" * $(class.name):");
+.if switches.digest ?= 1
+    printf ("\\n");
+.endif
 
     //  Silence an "unused" warning by "using" the verbose variable
     if (verbose) {;}
@@ -1145,29 +1164,43 @@ $(class.name)_test (bool verbose)
 
 .   for field where !defined (value)
 .       if type = "number"
-    $(class.name)_set_$(name) (self, 123);
+    $(class.name)_set_$(name) (self, $(->test.?123:));
 .       elsif type = "octets"
+.           if defined (->test)
+    byte $(name)_data [$(CLASS.NAME)_$(FIELD.NAME)_SIZE] = "$(->test.)";
+    $(class.name)_set_$(name) (self, $(name)_data);
+.           else
     byte $(name)_data [$(CLASS.NAME)_$(FIELD.NAME)_SIZE];
     memset ($(name)_data, 123, $(CLASS.NAME)_$(FIELD.NAME)_SIZE);
     $(class.name)_set_$(name) (self, $(name)_data);
+.           endif
 .       elsif type = "string" | type = "longstr"
-    $(class.name)_set_$(name) (self, "Life is short but Now lasts for ever");
+    $(class.name)_set_$(name) (self, "$(->test.?"Life is short but Now lasts for ever":)");
 .       elsif type = "strings"
     zlist_t *$(message.name)_$(name) = zlist_new ();
+.           if defined (->test)
+.               for test
+    zlist_append ($(message.name)_$(name), "$(test.)");
+.               endfor
+.           else
     zlist_append ($(message.name)_$(name), "Name: Brutus");
     zlist_append ($(message.name)_$(name), "Age: 43");
+.           endif
     $(class.name)_set_$(name) (self, &$(message.name)_$(name));
 .       elsif type = "chunk" | type = "frame"
-    z$(type)_t *$(message.name)_$(name) = z$(type)_new ("Captcha Diem", 12);
+    z$(type)_t *$(message.name)_$(name) = z$(type)_new ("$(->test.?"Captcha Diem":)", $(->test.??12?string.length(->test.):));
     $(class.name)_set_$(name) (self, &$(message.name)_$(name));
 .       elsif type = "uuid"
     zuuid_t *$(message.name)_$(name) = zuuid_new ();
+.           if defined (->test)
+    zuuid_set_str ($(message.name)_$(name), "$(->test.)");
+.           endif
     zuuid_t *$(message.name)_$(name)_dup = zuuid_dup ($(message.name)_$(name));
     $(class.name)_set_$(name) (self, &$(message.name)_$(name));
 .       elsif type = "msg"
     zmsg_t *$(message.name)_$(name) = zmsg_new ();
     $(class.name)_set_$(name) (self, &$(message.name)_$(name));
-    zmsg_addstr ($(class.name)_$(name) (self), "Hello, World");
+    zmsg_addstr ($(class.name)_$(name) (self), "$(->test.?"Hello, World":)");
 .       endif
 .   endfor
     //  Send twice
@@ -1179,22 +1212,36 @@ $(class.name)_test (bool verbose)
         assert ($(class.name)_routing_id (self));
 .   for field where !defined (value)
 .       if type = "number"
-        assert ($(class.name)_$(name) (self) == 123);
+        assert ($(class.name)_$(name) (self) == $(->test.?123:));
 .       elsif type = "octets"
+.           if defined (->test)
+        assert (memcmp ($(class.name)_$(name) (self), "$(->test.)", $(CLASS.NAME)_$(FIELD.NAME)_SIZE) == 0);
+.           else
         assert ($(class.name)_$(name) (self) [0] == 123);
         assert ($(class.name)_$(name) (self) [$(CLASS.NAME)_$(FIELD.NAME)_SIZE - 1] == 123);
+.           endif
 .       elsif type = "string" | type = "longstr"
-        assert (streq ($(class.name)_$(name) (self), "Life is short but Now lasts for ever"));
+        assert (streq ($(class.name)_$(name) (self), "$(->test.?"Life is short but Now lasts for ever":)"));
 .       elsif type = "strings"
         zlist_t *$(name) = $(class.name)_get_$(name) (self);
+.           if defined (->test)
+.               for test
+.                   if first ()
+        assert (streq ((char *) zlist_first ($(name)), "$(test.)"));
+.                   else
+        assert (streq ((char *) zlist_next ($(name)), "$(test.)"));
+.                   endif
+.               endfor
+.           else
         assert (zlist_size ($(name)) == 2);
         assert (streq ((char *) zlist_first ($(name)), "Name: Brutus"));
         assert (streq ((char *) zlist_next ($(name)), "Age: 43"));
+.           endif
         zlist_destroy (&$(name));
 .       elsif type = "chunk"
-        assert (memcmp (zchunk_data ($(class.name)_$(name) (self)), "Captcha Diem", 12) == 0);
+        assert (memcmp (zchunk_data ($(class.name)_$(name) (self)), "$(->test.?"Captcha Diem":)", $(->test.??12?string.length(->test.):)) == 0);
 .       elsif type = "frame"
-        assert (zframe_streq ($(class.name)_$(name) (self), "Captcha Diem"));
+        assert (zframe_streq ($(class.name)_$(name) (self), "$(->test.?"Captcha Diem":)"));
 .       elsif type = "msg"
         assert (zmsg_size ($(class.name)_$(name) (self)) == 1);
 .       elsif type = "uuid"

--- a/src/zproto_example.c
+++ b/src/zproto_example.c
@@ -1482,14 +1482,14 @@ zproto_example_test (bool verbose)
     zproto_example_set_id (self, ZPROTO_EXAMPLE_TYPES);
 
     zproto_example_set_sequence (self, 123);
-    zproto_example_set_client_forename (self, "Life is short but Now lasts for ever");
-    zproto_example_set_client_surname (self, "Life is short but Now lasts for ever");
-    zproto_example_set_client_mobile (self, "Life is short but Now lasts for ever");
-    zproto_example_set_client_email (self, "Life is short but Now lasts for ever");
-    zproto_example_set_supplier_forename (self, "Life is short but Now lasts for ever");
-    zproto_example_set_supplier_surname (self, "Life is short but Now lasts for ever");
-    zproto_example_set_supplier_mobile (self, "Life is short but Now lasts for ever");
-    zproto_example_set_supplier_email (self, "Life is short but Now lasts for ever");
+    zproto_example_set_client_forename (self, "Lucius Junius");
+    zproto_example_set_client_surname (self, "Brutus");
+    zproto_example_set_client_mobile (self, "01234567890");
+    zproto_example_set_client_email (self, "brutus@example.com");
+    zproto_example_set_supplier_forename (self, "Leslie");
+    zproto_example_set_supplier_surname (self, "Lamport");
+    zproto_example_set_supplier_mobile (self, "01987654321");
+    zproto_example_set_supplier_email (self, "lamport@example.com");
     //  Send twice
     zproto_example_send (self, output);
     zproto_example_send (self, output);
@@ -1498,14 +1498,14 @@ zproto_example_test (bool verbose)
         zproto_example_recv (self, input);
         assert (zproto_example_routing_id (self));
         assert (zproto_example_sequence (self) == 123);
-        assert (streq (zproto_example_client_forename (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_client_surname (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_client_mobile (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_client_email (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_supplier_forename (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_supplier_surname (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_supplier_mobile (self), "Life is short but Now lasts for ever"));
-        assert (streq (zproto_example_supplier_email (self), "Life is short but Now lasts for ever"));
+        assert (streq (zproto_example_client_forename (self), "Lucius Junius"));
+        assert (streq (zproto_example_client_surname (self), "Brutus"));
+        assert (streq (zproto_example_client_mobile (self), "01234567890"));
+        assert (streq (zproto_example_client_email (self), "brutus@example.com"));
+        assert (streq (zproto_example_supplier_forename (self), "Leslie"));
+        assert (streq (zproto_example_supplier_surname (self), "Lamport"));
+        assert (streq (zproto_example_supplier_mobile (self), "01987654321"));
+        assert (streq (zproto_example_supplier_email (self), "lamport@example.com"));
     }
 
     zproto_example_destroy (&self);

--- a/src/zproto_example.c
+++ b/src/zproto_example.c
@@ -317,8 +317,6 @@ zproto_example_recv (zproto_example_t *self, zsock_t *input)
     self->needle = (byte *) zmq_msg_data (&frame);
     self->ceiling = self->needle + zmq_msg_size (&frame);
 
-    zdigest_t * digest = zdigest_new ();
-    
     uint16_t signature;
     GET_NUMBER2 (signature);
     if (signature != (0xAAA0 | 0)) {
@@ -332,10 +330,6 @@ zproto_example_recv (zproto_example_t *self, zsock_t *input)
 
     switch (self->id) {
         case ZPROTO_EXAMPLE_LOG:
-            zdigest_update (digest, (byte *) zmq_msg_data (&frame), zmq_msg_size (&frame));
-            // This is a hacky way of sending digests to the "./selftest -d" script through stderr
-            fprintf(stderr, "LOG-%s\n", zdigest_string (digest));
-
             GET_NUMBER2 (self->sequence);
             {
                 uint16_t version;
@@ -355,10 +349,6 @@ zproto_example_recv (zproto_example_t *self, zsock_t *input)
             break;
 
         case ZPROTO_EXAMPLE_STRUCTURES:
-            zdigest_update (digest, (byte *) zmq_msg_data (&frame), zmq_msg_size (&frame));
-            // This is a hacky way of sending digests to the "./selftest -d" script through stderr
-            fprintf(stderr, "STRUCTURES-%s\n", zdigest_string (digest));
-
             GET_NUMBER2 (self->sequence);
             {
                 size_t list_size;
@@ -389,10 +379,6 @@ zproto_example_recv (zproto_example_t *self, zsock_t *input)
             break;
 
         case ZPROTO_EXAMPLE_BINARY:
-            zdigest_update (digest, (byte *) zmq_msg_data (&frame), zmq_msg_size (&frame));
-            // This is a hacky way of sending digests to the "./selftest -d" script through stderr
-            fprintf(stderr, "BINARY-%s\n", zdigest_string (digest));
-
             GET_NUMBER2 (self->sequence);
             GET_OCTETS (self->flags, 4);
             {
@@ -430,10 +416,6 @@ zproto_example_recv (zproto_example_t *self, zsock_t *input)
             break;
 
         case ZPROTO_EXAMPLE_TYPES:
-            zdigest_update (digest, (byte *) zmq_msg_data (&frame), zmq_msg_size (&frame));
-            // This is a hacky way of sending digests to the "./selftest -d" script through stderr
-            fprintf(stderr, "TYPES-%s\n", zdigest_string (digest));
-
             GET_NUMBER2 (self->sequence);
             GET_STRING (self->client_forename);
             GET_STRING (self->client_surname);
@@ -450,14 +432,12 @@ zproto_example_recv (zproto_example_t *self, zsock_t *input)
             goto malformed;
     }
     //  Successful return
-    zdigest_destroy (&digest);
     zmq_msg_close (&frame);
     return 0;
 
     //  Error returns
     malformed:
         zsys_warning ("zproto_example: zproto_example malformed message, fail");
-        zdigest_destroy (&digest);
         zmq_msg_close (&frame);
         return -1;              //  Invalid message
 }
@@ -1371,7 +1351,6 @@ int
 zproto_example_test (bool verbose)
 {
     printf (" * zproto_example:");
-    printf ("\n");
 
     //  Silence an "unused" warning by "using" the verbose variable
     if (verbose) {;}

--- a/src/zproto_example.c
+++ b/src/zproto_example.c
@@ -1362,13 +1362,16 @@ zproto_example_test (bool verbose)
     zproto_example_destroy (&self);
 
     //  Create pair of sockets we can send through
-    zsock_t *input = zsock_new (ZMQ_ROUTER);
-    assert (input);
-    zsock_connect (input, "inproc://selftest-zproto_example");
-
+    //  We must bind before connect if we wish to remain compatible with ZeroMQ < v4
     zsock_t *output = zsock_new (ZMQ_DEALER);
     assert (output);
-    zsock_bind (output, "inproc://selftest-zproto_example");
+    int rc = zsock_bind (output, "inproc://selftest-zproto_example");
+    assert (rc == 0);
+
+    zsock_t *input = zsock_new (ZMQ_ROUTER);
+    assert (input);
+    rc = zsock_connect (input, "inproc://selftest-zproto_example");
+    assert (rc == 0);
 
     //  Encode/send/decode and verify each message type
     int instance;

--- a/src/zproto_example.xml
+++ b/src/zproto_example.xml
@@ -186,7 +186,7 @@ them from other fields:
 <message
     name = "TYPES"
     id = "4"
-    digest = "CC660A16CEA7C4D6B864E61279F301E8A30D6620"
+    digest = "DEE674A1BCAC455B7CD1801F4008C65D0A37B2EA"
     >
     <field name = "client" type = "person">
         Client contact

--- a/src/zproto_example.xml
+++ b/src/zproto_example.xml
@@ -51,15 +51,15 @@ to put the second lot into hash tables (the 'hash' type).
 
 OK, let's see some meat.
 
-<message name = "LOG" id = "1">
+<message name = "LOG" id = "1" digest = "B90F4926D4662B319C0EC113794B0F27D9336A23">
     <field name = "version" type = "number" size = "2" value = "3">Version</field>
-    <field name = "level" type = "number" size = "1">Log severity level</field>
-    <field name = "event" type = "number" size = "1">Type of event</field>
-    <field name = "node" type = "number" size = "2">Sending node</field>
-    <field name = "peer" type = "number" size = "2">Refers to this peer</field>
-    <field name = "time" type = "number" size = "8">Log date/time</field>
-    <field name = "host" type = "string">Originating hostname</field>
-    <field name = "data" type = "longstr">Actual log message</field>
+    <field name = "level" type = "number" size = "1">Log severity level<test>2</test></field>
+    <field name = "event" type = "number" size = "1">Type of event<test>3</test></field>
+    <field name = "node" type = "number" size = "2">Sending node<test>45536</test></field>
+    <field name = "peer" type = "number" size = "2">Refers to this peer<test>65535</test></field>
+    <field name = "time" type = "number" size = "8">Log date/time<test>1427261426</test></field>
+    <field name = "host" type = "string">Originating hostname<test>localhost</test></field>
+    <field name = "data" type = "longstr">Actual log message<test>This is the message to log</test></field>
 Log an event.
 </message>
 
@@ -83,9 +83,18 @@ use this for e.g. version detection.
 
 zproto supports lists and hashes of strings:
 
-<message name = "STRUCTURES" id = "2">
-    <field name = "aliases" type = "strings">List of strings</field>
-    <field name = "headers" type = "hash">Other random properties</field>
+<message name = "STRUCTURES" id = "2" digest = "BC804854A96B9CC28E74400A9586B8BE1F638384">
+    <field name = "aliases" type = "strings">
+        List of strings
+        <test>First alias</test>
+        <test>Second alias</test>
+        <test>Third alias</test>
+    </field>
+    <field name = "headers" type = "hash">
+        Other random properties
+        <test key = "endpoint">tcp://localhost</test>
+        <test key = "port">5665</test>
+    </field>
 This message contains a list and a hash.
 </message>
 
@@ -112,21 +121,36 @@ zproto supports several kinds of binary data:
   in other data. If you use a "msg" type field, it must be the last
   field in the message.
 
-<message name = "BINARY" id = "3">
-    <field name = "flags" type = "octets" size = "4">A set of flags</field>
-    <field name = "public key" type = "chunk">Our public key</field>
-    <field name = "identifier" type = "uuid">Unique identity</field>
-    <field name = "address" type = "frame">Return address as frame</field>
-    <field name = "content" type = "msg">Message to be delivered</field>
+<message name = "BINARY" id = "3" digest = "740CAF04158436B4A81B844135A8A1DC9E4F8A54">
+    <field name = "flags" type = "octets" size = "4">A set of flags<test>b38c</test></field>
+    <field name = "public key" type = "chunk">Our public key<test>89f5ffe70d747869dfe8</test></field>
+    <field name = "identifier" type = "uuid">Unique identity<test>3a60e6850a1e4cc15f3bfd4b42bc6b3e</test></field>
+    <field name = "address" type = "frame">Return address as frame<test>0206f99f6137d9fe380f</test></field>
+    <field name = "content" type = "msg">
+        Message to be delivered
+        <test>728a92c6749235ba7002</test>
+    </field>
 Deliver a multi-part message.
 </message>
 
 As well as the built-in types, you can define your own types, by composing
 them from other fields:
 
-<message name = "TYPES" id = "4">
-    <field name = "client" type = "person">Client contact</field>
-    <field name = "supplier" type = "person">Supplier contact</field>
+<message name = "TYPES" id = "4" digest = "CC660A16CEA7C4D6B864E61279F301E8A30D6620">
+    <field name = "client" type = "person">
+        Client contact
+        <test key = "forename">Lucius Junius</test>
+        <test key = "surname">Brutus</test>
+        <test key = "mobile">01234567890</test>
+        <test key = "email">brutus@example.com</test>
+    </field>
+    <field name = "supplier" type = "person">
+        Supplier contact
+        <test key = "forename">Leslie</test>
+        <test key = "surname">Lamport</test>
+        <test key = "mobile">01987654321</test>
+        <test key = "email">lamport@example.com</test>
+    </field>
 Demonstrate custom-defined types
 </message>
 

--- a/src/zproto_example.xml
+++ b/src/zproto_example.xml
@@ -51,15 +51,42 @@ to put the second lot into hash tables (the 'hash' type).
 
 OK, let's see some meat.
 
-<message name = "LOG" id = "1" digest = "B90F4926D4662B319C0EC113794B0F27D9336A23">
-    <field name = "version" type = "number" size = "2" value = "3">Version</field>
-    <field name = "level" type = "number" size = "1">Log severity level<test>2</test></field>
-    <field name = "event" type = "number" size = "1">Type of event<test>3</test></field>
-    <field name = "node" type = "number" size = "2">Sending node<test>45536</test></field>
-    <field name = "peer" type = "number" size = "2">Refers to this peer<test>65535</test></field>
-    <field name = "time" type = "number" size = "8">Log date/time<test>1427261426</test></field>
-    <field name = "host" type = "string">Originating hostname<test>localhost</test></field>
-    <field name = "data" type = "longstr">Actual log message<test>This is the message to log</test></field>
+<message
+    name = "LOG"
+    id = "1"
+    digest = "B90F4926D4662B319C0EC113794B0F27D9336A23"
+    >
+    <field name = "version" type = "number" size = "2" value = "3">
+        Version
+    </field>
+    <field name = "level" type = "number" size = "1">
+        Log severity level
+        <test>2</test>
+    </field>
+    <field name = "event" type = "number" size = "1">
+        Type of event
+        <test>3</test>
+    </field>
+    <field name = "node" type = "number" size = "2">
+        Sending node
+        <test>45536</test>
+    </field>
+    <field name = "peer" type = "number" size = "2">
+        Refers to this peer
+        <test>65535</test>
+    </field>
+    <field name = "time" type = "number" size = "8">
+        Log date/time
+        <test>1427261426</test>
+    </field>
+    <field name = "host" type = "string">
+        Originating hostname
+        <test>localhost</test>
+    </field>
+    <field name = "data" type = "longstr">
+        Actual log message
+        <test>This is the message to log</test>
+    </field>
 Log an event.
 </message>
 
@@ -83,7 +110,11 @@ use this for e.g. version detection.
 
 zproto supports lists and hashes of strings:
 
-<message name = "STRUCTURES" id = "2" digest = "BC804854A96B9CC28E74400A9586B8BE1F638384">
+<message
+    name = "STRUCTURES"
+    id = "2"
+    digest = "BC804854A96B9CC28E74400A9586B8BE1F638384"
+    >
     <field name = "aliases" type = "strings">
         List of strings
         <test>First alias</test>
@@ -121,11 +152,27 @@ zproto supports several kinds of binary data:
   in other data. If you use a "msg" type field, it must be the last
   field in the message.
 
-<message name = "BINARY" id = "3" digest = "740CAF04158436B4A81B844135A8A1DC9E4F8A54">
-    <field name = "flags" type = "octets" size = "4">A set of flags<test>b38c</test></field>
-    <field name = "public key" type = "chunk">Our public key<test>89f5ffe70d747869dfe8</test></field>
-    <field name = "identifier" type = "uuid">Unique identity<test>3a60e6850a1e4cc15f3bfd4b42bc6b3e</test></field>
-    <field name = "address" type = "frame">Return address as frame<test>0206f99f6137d9fe380f</test></field>
+<message
+    name = "BINARY"
+    id = "3"
+    digest = "740CAF04158436B4A81B844135A8A1DC9E4F8A54"
+    >
+    <field name = "flags" type = "octets" size = "4">
+        A set of flags
+        <test>b38c</test>
+    </field>
+    <field name = "public key" type = "chunk">
+        Our public key
+        <test>89f5ffe70d747869dfe8</test>
+    </field>
+    <field name = "identifier" type = "uuid">
+        Unique identity
+        <test>3a60e6850a1e4cc15f3bfd4b42bc6b3e</test>
+    </field>
+    <field name = "address" type = "frame">
+        Return address as frame
+        <test>0206f99f6137d9fe380f</test>
+    </field>
     <field name = "content" type = "msg">
         Message to be delivered
         <test>728a92c6749235ba7002</test>
@@ -136,7 +183,11 @@ Deliver a multi-part message.
 As well as the built-in types, you can define your own types, by composing
 them from other fields:
 
-<message name = "TYPES" id = "4" digest = "CC660A16CEA7C4D6B864E61279F301E8A30D6620">
+<message
+    name = "TYPES"
+    id = "4"
+    digest = "CC660A16CEA7C4D6B864E61279F301E8A30D6620"
+    >
     <field name = "client" type = "person">
         Client contact
         <test key = "forename">Lucius Junius</test>

--- a/src/zproto_lib.gsl
+++ b/src/zproto_lib.gsl
@@ -73,6 +73,7 @@ function resolve_types ()
                         field.type = type_field.type
                         field.size = type_field.size? 0
                         field. = type_field.?''
+                        copy original_field->test (key = type_field.name) to field
                     endnew
                 endfor
                 delete original_field


### PR DESCRIPTION
To test the integration of codecs now we have tests message with a digest of its frame content. Each codec can run through test messages and make sure its implementation is compatible with the
reference implementation.

To generate digests automaticly you need to first run gsl script with digest switch then the selftest script with -d swithc

    gsl -digest:1 zproto_example.xml
    ./selftest -d

This will update zproto_example.xml file with new digests. You will need to regenerate digests if you changed the message tests in zproto_example.xml.

This chnage is backwards compatible and shouldn't break your code so please report any breaks.