### PR TITLE
Problem: engine_set_connected() can raise compiler warning

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -675,6 +675,7 @@ s_satisfy_pedantic_compilers (void)
     engine_set_timeout (NULL, 0);
     engine_set_wakeup_event (NULL, 0, NULL_event);
     engine_handle_socket (NULL, 0, NULL);
+    engine_set_connected (NULL, 0);
 }
 
 


### PR DESCRIPTION
Solution: add to s_satisfy_pedantic_compilers().