### PR TITLE
Problem: Pipe handler stops when unexpected error happens

### DIFF
--- a/src/zproto_server_go.gsl
+++ b/src/zproto_server_go.gsl
@@ -386,10 +386,10 @@ func (s *server) handlePipe(i interface{}) (err error) {
 		s.routerEndpoint = msg.arg.(string)
 		s.port, err = bind(s.router, s.routerEndpoint)
 		if err != nil {
-.if switches.trace ?= 1
-			log.Println(err)
-.endif
-			return err
+			if s.verbose {
+				log.Println(err)
+			}
+			return nil
 		}
 
 		s.addSocketHandler(s.router, zmq.POLLIN, func(e zmq.State) error { return s.handleProtocol() })
@@ -408,7 +408,10 @@ func (s *server) handlePipe(i interface{}) (err error) {
 
 		info, err := os.Stat(filename)
 		if err != nil {
-			return err
+			if s.verbose {
+				log.Println(err)
+			}
+			return nil
 		}
 
 		if s.configInfo != nil &&
@@ -421,17 +424,26 @@ func (s *server) handlePipe(i interface{}) (err error) {
 		s.configInfo = info
 		data, err := ioutil.ReadFile(filename)
 		if err != nil {
-			return err
+			if s.verbose {
+				log.Println(err)
+			}
+			return nil
 		}
 		err = zpl.Unmarshal(data, &s.config)
 		if err != nil {
-			return err
+			if s.verbose {
+				log.Println(err)
+			}
+			return nil
 		}
 
 	case cmdSet:
 		args := msg.arg.([]string)
 		if len(args) < 2 {
-			return errors.New("Not enough arguments for set command")
+			if s.verbose {
+				log.Println("Not enough arguments for set command")
+			}
+			return nil
 		}
 
 		// path := args[0]
@@ -444,7 +456,10 @@ func (s *server) handlePipe(i interface{}) (err error) {
 	default:
 		r, err := s.method(msg)
 		if err != nil {
-			return err
+			if s.verbose {
+				log.Println(err)
+			}
+			return nil
 		}
 		if r != nil {
 			select {


### PR DESCRIPTION
Solution: Do not kill the handler loop by returning error, just log the error