### PR TITLE
Problem: _connected method is corrupting memory

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -1135,10 +1135,10 @@ bool
 $(class.name)_connected ($(class.name)_t *self)
 {
     assert (self);
-    bool connected;
+    int connected;
     zsock_send (self->actor, "s", "$CONNECTED");
     zsock_recv (self->actor, "i", &connected);
-    return connected;
+    return (bool) connected;
 }
 
 


### PR DESCRIPTION
The "i" picture expects int, whereas the method is providing a bool.
This results in rather nasty heap corruption.

Solution: use int and cast to bool.