### PR TITLE
fix is_$(class) template

### DIFF
--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -536,6 +536,8 @@ is_$(class.name) (zmsg_t *msg)
         return false;
 
     zframe_t *frame = zmsg_first (msg);
+    if (frame == NULL)
+        return false;
 
     //  Get and check protocol signature
     $(class.name)_t *self = $(class.name)_new (0);


### PR DESCRIPTION
Problem:
    on malformed message is_$(CLASS) function crashes on assert in zframe_data(frame).

Solution:
    check whether frame is extracted