### PR TITLE
Problem: Java codec generates duplicate variables in switch

### DIFF
--- a/src/zproto_codec_java.gsl
+++ b/src/zproto_codec_java.gsl
@@ -297,6 +297,7 @@ public class $(ClassName) implements java.io.Closeable
             switch (self.id) {
 .for class.message
             case $(MESSAGE.NAME):
+              {
 .   for field
 .       if type = "number"
                 self.$(name) = self.getNumber$(size) ();
@@ -355,6 +356,7 @@ public class $(ClassName) implements java.io.Closeable
 .       endif
 .    endfor
                 break;
+              }
 
 .endfor
             default:


### PR DESCRIPTION
Solution: use local scopes in each message block so there's no
risk of duplicate variables.