### PR TITLE
Problem: over-zealous replacement of class name

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -1436,7 +1436,7 @@ client_terminate (client_t *self)
 void
 $(class.name)_test (bool verbose)
 {
-    printf (" * %s: ");
+    printf (" * $(class.name): ");
     if (verbose)
         printf ("\\n");
 


### PR DESCRIPTION
Solution: revert print of class name in selftest