### PR TITLE
Fixes to client heartbeating

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -477,13 +477,15 @@ typedef struct {
     bool connected;             //  True if client is connected
     bool terminated;            //  True if client is shutdown
     bool fsm_stopped;           //  "terminate" action called
-    size_t timeout;             //  inactivity timeout, msecs
+    size_t expiry;              //  Expiry timer, msecs
+    size_t heartbeat;           //  Heartbeat timer, msecs
     state_t state;              //  Current state
     event_t event;              //  Current event
     event_t next_event;         //  The next event
     event_t exception;          //  Exception event, if any
-    int expiry_timer;           //  zloop timer for timeouts
+    int expiry_timer;           //  zloop timer for expiry
     int wakeup_timer;           //  zloop timer for alarms
+    int heartbeat_timer;        //  zloop timer for heartbeat
     event_t wakeup_event;       //  Wake up with this event
     char log_prefix [41];       //  Log prefix string
 } s_client_t;
@@ -498,9 +500,13 @@ static void
     s_client_execute (s_client_t *self, event_t event);
 static int
     s_client_handle_wakeup (zloop_t *loop, int timer_id, void *argument);
+.if count (class.event, name = "heartbeat")
+static int
+    s_client_handle_heartbeat (zloop_t *loop, int timer_id, void *argument);
+.endif
 .if count (class.event, name = "expired")
 static int
-    s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument);
+    s_client_handle_expiry (zloop_t *loop, int timer_id, void *argument);
 .endif
 static void
     s_satisfy_pedantic_compilers (void);
@@ -618,26 +624,52 @@ engine_set_wakeup_event (client_t *client, size_t delay, event_t event)
     }
 }
 
-//  Set heartbeat timeout. By default, the timeout is zero, meaning
-//  infinite. Setting a non-zero timeout causes the state machine to
-//  receive an "expired" event if is no incoming traffic for that many
-//  milliseconds. This cycles over and over until/unless the code sets
-//  a zero timeout. The state machine must handle the "expired" event.
+//  Set a heartbeat timer. The interval is in msecs and must be
+//  non-zero. The state machine must handle the "heartbeat" event.
+//  The heartbeat happens every interval no matter what traffic the
+//  client is sending or receiving.
 
 static void
-engine_set_timeout (client_t *client, size_t timeout)
+engine_set_heartbeat (client_t *client, size_t heartbeat)
 {
     if (client) {
         s_client_t *self = (s_client_t *) client;
-        self->timeout = timeout;
+        self->heartbeat = heartbeat;
+.if count (class.event, name = "heartbeat")
+        if (self->heartbeat_timer) {
+            zloop_timer_end (self->loop, self->heartbeat_timer);
+            self->heartbeat_timer = 0;
+        }
+        if (self->heartbeat)
+            self->heartbeat_timer = zloop_timer (
+                self->loop, self->heartbeat, 1, s_client_handle_heartbeat, self);
+.endif
+    }
+}
+
+
+//  Set expiry timer. Setting a non-zero expiry causes the state machine
+//  to receive an "expired" event if is no incoming traffic for that many
+//  milliseconds. This cycles over and over until/unless the code sets a
+//  zero expiry. The state machine must handle the "expired" event.
+
+//  Macro to support deprecated name: remove after 2016-07-31
+#define engine_set_timeout engine_set_expiry
+
+static void
+engine_set_expiry (client_t *client, size_t expiry)
+{
+    if (client) {
+        s_client_t *self = (s_client_t *) client;
+        self->expiry = expiry;
 .if count (class.event, name = "expired")
         if (self->expiry_timer) {
             zloop_timer_end (self->loop, self->expiry_timer);
             self->expiry_timer = 0;
         }
-        if (self->timeout)
+        if (self->expiry)
             self->expiry_timer = zloop_timer (
-                self->loop, self->timeout, 1, s_client_handle_timeout, self);
+                self->loop, self->expiry, 1, s_client_handle_expiry, self);
 .endif
     }
 }
@@ -680,7 +712,8 @@ s_satisfy_pedantic_compilers (void)
 {
     engine_set_next_event (NULL, NULL_event);
     engine_set_exception (NULL, NULL_event);
-    engine_set_timeout (NULL, 0);
+    engine_set_heartbeat (NULL, 0);
+    engine_set_expiry (NULL, 0);
     engine_set_wakeup_event (NULL, 0, NULL_event);
     engine_handle_socket (NULL, 0, NULL);
     engine_set_connected (NULL, 0);
@@ -828,19 +861,37 @@ s_client_execute (s_client_t *self, event_t event)
 }
 
 .if count (class.event, name = "expired")
-//  zloop callback when client inactivity timer expires
+//  zloop callback when client heartbeat timer expires
 
 static int
-s_client_handle_timeout (zloop_t *loop, int timer_id, void *argument)
+s_client_handle_heartbeat (zloop_t *loop, int timer_id, void *argument)
+{
+    s_client_t *self = (s_client_t *) argument;
+    s_client_execute (self, heartbeat_event);
+    if (self->terminated)
+        return -1;
+
+    if (self->heartbeat > 0)
+        self->heartbeat_timer = zloop_timer (
+            loop, self->heartbeat, 1, s_client_handle_heartbeat, self);
+    return 0;
+}
+
+.endif
+.if count (class.event, name = "expired")
+//  zloop callback when client expiry timeout expires
+
+static int
+s_client_handle_expiry (zloop_t *loop, int timer_id, void *argument)
 {
     s_client_t *self = (s_client_t *) argument;
     s_client_execute (self, expired_event);
     if (self->terminated)
         return -1;
 
-    if (self->timeout > 0)
+    if (self->expiry > 0)
         self->expiry_timer = zloop_timer (
-            loop, self->timeout, 1, s_client_handle_timeout, self);
+            loop, self->expiry, 1, s_client_handle_expiry, self);
     return 0;
 }
 
@@ -987,10 +1038,10 @@ s_client_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
             zloop_timer_end (self->loop, self->expiry_timer);
             self->expiry_timer = 0;
         }
-        //  Reset expiry timer if timeout is not zero
-        if (self->timeout)
+        //  Reset expiry timer if expiry timeout not zero
+        if (self->expiry)
             self->expiry_timer = zloop_timer (
-                self->loop, self->timeout, 1, s_client_handle_timeout, self);
+                self->loop, self->expiry, 1, s_client_handle_expiry, self);
 .endif
         s_client_execute (self, s_protocol_event (self, self->message));
         if (self->terminated)

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -738,6 +738,9 @@ s_server_config_global (s_server_t *self)
     //  Default client timeout is 60 seconds
     self->timeout = atoi (
         zconfig_resolve (self->config, "server/timeout", "60000"));
+    //  Minimum non-zero value is 2 x client heartbeating
+    if (self->timeout && self->timeout < 2000)
+        self->timeout = 2000;
     zloop_set_ticket_delay (self->loop, self->timeout);
 
     //  Do we want to run server in the background?


### PR DESCRIPTION
Note, engine_set_timeout is now deprecated in favor of engine_set_expiry. 

To do heartbeating client must use engine_set_heartbeat.