### PR TITLE
Problem: does not assert on zsock_new failure

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -756,6 +756,7 @@ s_server_new (zsock_t *pipe)
 
     self->pipe = pipe;
     self->router = zsock_new (ZMQ_ROUTER);
+    assert (self->router);
     //  By default the socket will discard outgoing messages above the
     //  HWM of 1,000. This isn't helpful for high-volume streaming. We
     //  will use a unbounded queue here. If applications need to guard


### PR DESCRIPTION
As a result the code crashes later and in opaque ways.

Solution add an assertion; if the server cannot create its router
socket then the app cannot run in any sane fashion.