### PR TITLE
problem: download and use ZProto with NetMQ is complicated

### DIFF
--- a/packaging/nuget/NetMQ.zproto.nuspec
+++ b/packaging/nuget/NetMQ.zproto.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>NetMQ.zproto</id>
+        <version>0.1.5</version>
+        <title>NetMQ ZProto</title>
+        <authors>somdoron</authors>
+        <licenseUrl>https://raw.github.com/zeromq/zproto/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/zeromq/zproto</projectUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>Generate NetMQ binary messages.</description>
+        <tags>NetMQ, zeromq, codegen, zproto</tags>
+        <dependencies>
+           <dependency id="gsl" version="4.1.0.1" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\..\src\zproto_codec_cs.gsl" target="content\zproto\zproto_codec_cs.gsl" />
+        <file src="..\..\src\zproto_lib.gsl" target="content\zproto\zproto_lib.gsl" />
+        <file src="..\..\src\zproto_lib_cs.gsl" target="content\zproto\zproto_lib_cs.gsl" />
+        <file src="..\..\src\zproto_example_cs.xml" target="content\zproto\Example.xml" />
+    </files>
+</package>

--- a/src/zproto_codec_cs.gsl
+++ b/src/zproto_codec_cs.gsl
@@ -41,7 +41,11 @@ namespace $(class.namespace)
 	/// <summary>
 	/// $(class.title:)
 	/// </summary>
-	public class $(class.name:Pascal)
+.if class.modifier <> ""
+	$(class.modifier) class $(class.name:Pascal)
+.else
+	class $(class.name:Pascal)
+.endif
 	{
 		public class MessageException : Exception
 		{
@@ -773,6 +777,9 @@ using System.Text;
 using System.Collections.Generic;
 using NUnit.Framework;
 using NetMQ;
+.if class.namespace <> class.test_namespace
+using $(class.namespace);
+.endif
 
 namespace $(class.test_namespace)
 {

--- a/src/zproto_example_cs.xml
+++ b/src/zproto_example_cs.xml
@@ -7,6 +7,7 @@
     test_dir ="./csharp/ZProto.Tests"
     namespace ="ZProto"
     test_namespace="ZProto.Test"
+    modifier="public"
     >
 This is an example protocol designed to teach you how this stuff works.
 

--- a/src/zproto_lib_cs.gsl
+++ b/src/zproto_lib_cs.gsl
@@ -9,6 +9,7 @@ function set_cs_defaults ()
     class.test_dir ?= "."
     class.namespace ?= "ZProto"
     class.test_namespace ?= "ZProto.Tests"
+    class.modifier ?= ""
 
     class.export_macro ?= ""
     if class.export_macro <> ""


### PR DESCRIPTION
Solution: Publish zproto to nuget. This PR adds nuget packaging.

Also allow to set a modifier (public/private) on the generated NetMQ class. 