### PR TITLE
A version of zproto_server_c.gsl that supports "virtual" codecs

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -122,6 +122,7 @@ $(CLASS.EXPORT_MACRO)int
     $(class.name)_send ($(class.name)_t *self, zsock_t *output);
 
 .endif
+
 //  Print contents of message to stdout
 $(CLASS.EXPORT_MACRO)void
     $(class.name)_print ($(class.name)_t *self);
@@ -531,6 +532,8 @@ int
 $(class.name)_recv ($(class.name)_t *self, zmsg_t *input)
 {
     assert (input);
+    
+
     zframe_t *frame = zmsg_pop (input);
     if (!frame) {
         zsys_warning ("$(class.name): missing frames in message");

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -4,6 +4,9 @@
 #   Generates a server class for a protocol specification
 #   This manages ROUTER server talking to DEALER clients
 #
+#
+#   - if proto_class has the 'virtual' flag set, the server will use the appropriate zmsg_t calls transparently
+#
 include "zproto_lib.gsl"
 resolve_includes ()
 set_defaults ()
@@ -11,6 +14,8 @@ set_defaults ()
 #   Load message structures for this engine
 global.proto = xml.load_file (class.protocol_class + ".xml")
 class.proto = class.protocol_class
+
+
 
 #   Lowercase state/event/action names
 for class.state
@@ -591,7 +596,13 @@ s_client_free (void *argument)
 .               if defined (class.send_tracer)
                         $(class.send_tracer) ((server_t *) self->server);
 .               endif
+.               if global.proto.virtual ?= 1
+                        zmsg_t* msg = zmsg_new();
+                        $(proto)_send (self->server->message, msg);
+                        zmsg_send(&msg,self->server->router);
+.               else
                         $(proto)_send (self->server->message, self->server->router);
+.               endif                        
 .           elsif name = "terminate"
                         //  terminate
                         if (self->server->verbose)
@@ -943,8 +954,33 @@ s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
     //  We process as many messages as we can, to reduce the overhead
     //  of polling and the reactor:
     while (zsock_events (self->router) & ZMQ_POLLIN) {
+.   if global.proto.virtual ?= 1
+        zframe_t* routing_id = NULL;
+
+        //If the socket is a router, save the routing Id 
+        if (zsock_type (self->router) == ZMQ_ROUTER) {
+            routing_id = zframe_recv (self->router);
+            if (!routing_id || !zsock_rcvmore (self->router)) {
+                zsys_warning ("$(class.name): no routing ID");
+                return -1;          //  Interrupted or malformed
+            }
+        }
+        zmsg_t* recvmsg = zmsg_recv(self->router);
+        if(!recvmsg)
+            return -1;      //  Interrupted; exit zloop
+        if($(proto)_recv(self->message,recvmsg))
+            return -1; //Interrupted; malformed
+
+        //For router sockets, set the routing id of this messaged based on the value we saved
+        if(routing_id)
+        {    entropy_msg_set_routing_id(self->message,routing_id);
+             zframe_destroy(&routing_id);
+        }
+        
+.   else
         if ($(proto)_recv (self->message, self->router))
-            return -1;              //  Interrupted; exit zloop
+            return -1;      //  Interrupted; exit zloop
+.   endif             
 .if defined (class.receive_tracer)
         $(class.receive_tracer) ((server_t *) self);
 .endif


### PR DESCRIPTION
With Reference to issue: https://github.com/zeromq/zproto/issues/285

zproto_codec_c.gsl already supports "send/recv" methods that encode messages to zmsg_t format. These methods are only generated when virtual="1" is set in the .xml referenced by the  protocol_class property.

The downside is that servers generated by zproto_server_c.gsl cannot use message classes created with the virtual flag set.

Therefore, rather than implement separate encode/decode methods that are essentially copies of the methods generated when the virtual flag, I adapted zproto_server_c.gsl so that it detects if the protocol_class has the virtual flag set and generates appropriate wrapper code to generate & send the message as one would expect.


NOTE: there were several copies of the 'send' command that were adapted to messages. They all looked like copies of each other so I cleaned them up