### PR TITLE
Problem: int/boolean conversion warning on Windows

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -1204,7 +1204,7 @@ $(class.name)_connected ($(class.name)_t *self)
     int connected;
     zsock_send (self->actor, "s", "$CONNECTED");
     zsock_recv (self->actor, "i", &connected);
-    return (bool) connected;
+    return connected == 1;
 }
 
 


### PR DESCRIPTION
Solution: fix the template.