### PR TITLE
Problem: zproto isn't compatible with zproject

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -515,6 +515,7 @@ $(CLASS.EXPORT_MACRO)extern volatile int
 #endif
 
 #endif
+.endif
 .output "$(class.name)_engine.inc"
 /*  =========================================================================
     $(class.name)_engine - $(class.title:) engine


### PR DESCRIPTION
Specifically, it does not generate api/*.xml for its classes.

Solution: generate api/*.xml for codec and for client. The server
API isn't needed right away.

Unfinished work in progress...