### PR TITLE
Problem: class filename ext is still xml

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -286,7 +286,7 @@ endif
 .if switches.zproject ?= 1
 .   file.delete ("$(class.package_dir)/$(class.name).h")
 .   directory.create ("../api")
-.   output "../api/$(class.name).xml"
+.   output "../api/$(class.name).api"
 <!--
     $(class.name) - $(class.title:)
 

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -35,7 +35,7 @@ set_defaults ()
 .if switches.zproject ?= 1
 .   file.delete ("$(class.package_dir)/$(class.name).h")
 .   directory.create ("../api")
-.   output "../api/$(class.name).xml"
+.   output "../api/$(class.name).api"
 <!--
     $(class.name) - $(class.title:)
 


### PR DESCRIPTION
Solution: change zproto_client_c.gsl and zproto_codec_c.gsl to
create .api files instead of .xml