### PR TITLE
Problem: No need to specify WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,3 @@ RUN apt-get install -y build-essential libtool autoconf automake
 COPY . /tmp/zproto
 WORKDIR /tmp/zproto
 RUN ( ./autogen.sh; ./configure; make check; make install )
-
-WORKDIR /gsl


### PR DESCRIPTION
since zeromqorg/gsl was tuned
to accept $GSL_BUILD_DIR environment variable

Solution: Cleanup