### PR TITLE
Problem: libtool should be libtoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -2,7 +2,7 @@
 #
 #   Script to generate all required files from fresh git checkout.
 
-command -v libtool >/dev/null 2>&1
+command -v libtoolize >/dev/null 2>&1
 if  [ $? -ne 0 ]; then
     echo "autogen.sh: error: could not find libtool.  libtool is required to run autogen.sh." 1>&2
     exit 1


### PR DESCRIPTION
Apparently libtool needs to be issued as libtoolize. Other packages do this also.