### PR TITLE
Problem: set_verbose signature mismatch between src and header

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -530,7 +530,7 @@ $(header.:)
 .endfor
 //  Enable verbose tracing (animation) of state machine activity.
 $(CLASS.EXPORT_MACRO)void
-    $(class.name)_set_verbose (bool verbose);
+    $(class.name)_set_verbose ($(class.name)_t *self, bool verbose)
 
 //  Self test of this class
 $(CLASS.EXPORT_MACRO)void


### PR DESCRIPTION
Solution: use the signature from the src which includes the correct context

should fix #308 