### PR TITLE
Problem: class state not propagated to generated .api files

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -54,7 +54,11 @@ set_defaults ()
     $(string.trim (license.):block                                         )
 .   endfor
  -->
-<class name = "$(class.name)">
+<class name = "$(class.name)"\
+.   if defined (class.state)
+ state = "$(class.state)"\
+.       endif
+>
 .   for define
     <constant name = "$(define.name)" value = "$(define.value:)" />
 .   endfor


### PR DESCRIPTION
Solution: properly propagate class state value (stable, draft, legcy) to .api files if defined.