### PR TITLE
Problem: set_verbose declaration in zproto_client_c is missing a semicolon and causing build errors

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -535,7 +535,7 @@ $(header.:)
 .endfor
 //  Enable verbose tracing (animation) of state machine activity.
 $(CLASS.EXPORT_MACRO)void
-    $(class.name)_set_verbose ($(class.name)_t *self, bool verbose)
+    $(class.name)_set_verbose ($(class.name)_t *self, bool verbose);
 
 //  Self test of this class
 $(CLASS.EXPORT_MACRO)void


### PR DESCRIPTION
Solution: add the missing semicolon