### PR TITLE
Problem: Python codec generator is missing `self` parameter for the `id` function`

### DIFF
--- a/src/zproto_codec_python.gsl
+++ b/src/zproto_codec_python.gsl
@@ -461,7 +461,7 @@ class $(ClassName)(object):
     #  --------------------------------------------------------------------------
     #  Get/set the $(class.name) id
 
-    def id():
+    def id(self):
         return self._id
 
     def set_id(self, id):


### PR DESCRIPTION
Solution: add the parameter.