### PR TITLE
Problem: dot generator broke server generator

### DIFF
--- a/src/zproto_dot.gsl
+++ b/src/zproto_dot.gsl
@@ -11,7 +11,6 @@
 #   file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 function generate_dot
-    [gsl].shuffle = 1
     output "$(class.name).dot"
     >## Automatically generated from $(class.name).xml by gsl
     >digraph "$(class.name)" {


### PR DESCRIPTION
Solution: drop [gsl].shuffle = 1 line, which was apparently causing
generating of stub for handle_component_register and stub for
handle_list_components later on

fixes https://github.com/zeromq/zproto/pull/319