### PR TITLE
Problem: server generator contains a syntax error and `client` is

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -287,7 +287,7 @@ $(CLASS.EXPORT_MACRO)void
 
 .if class.virtual ?= 1
 //  Deserialize a $(class.name) from the specified message, popping
-//  as many frames as needed. Returns 0 if OK, -1 if there recv was
+//  as many frames as needed. Returns 0 if OK, -1 if the read was
 //  interrupted, or -2 if the message is malformed.
 $(CLASS.EXPORT_MACRO)int
     $(class.name)_recv ($(class.name)_t *self, zmsg_t *input);
@@ -298,7 +298,7 @@ $(CLASS.EXPORT_MACRO)int
 
 .else
 //  Receive a $(class.name) from the socket. Returns 0 if OK, -1 if
-//  the recv was interrupted, or -2 if the message is malformed.
+//  the read was interrupted, or -2 if the message is malformed.
 //  Blocks if there is no message waiting.
 $(CLASS.EXPORT_MACRO)int
     $(class.name)_recv ($(class.name)_t *self, zsock_t *input);

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -986,15 +986,8 @@ s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
         int rc = $(proto)_recv (self->message, recvmsg);
         if(rc == -1)
             return -1;      //  Interrupted; exit zloop
-        if(rc == -2) {
-.if count (class.event, name = "malformed")
-           s_client_execute (client, malformed_event);
-           continue;
-.else
-           return -1;       //  Malformed, but malformed_event doesn't exist
-                            //  -> exit zloop
-.endif
-        }
+        if(rc == -2)
+            continue;       //  Malformed; discard the message
 
         //For router sockets, set the routing id of this messaged based on the value we saved
         if(routing_id)
@@ -1003,18 +996,9 @@ s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
         }
         
 .   else
-        int rc = $(proto)_recv (self->message, self->router)
+        int rc = $(proto)_recv (self->message, self->router);
         if (rc == -1)
             return -1;      //  Interrupted; exit zloop
-        if(rc == -2) {
-.if count (class.event, name = "malformed")
-           s_client_execute (client, malformed_event);
-           continue;
-.else
-           return -1;       //  Malformed, but malformed_event doesn't exist
-                            //  -> exit zloop
-.endif
-        }
 
 .   endif             
 .   if defined (class.receive_tracer)
@@ -1038,6 +1022,15 @@ s_server_handle_protocol (zloop_t *loop, zsock_t *reader, void *argument)
         if (client->ticket)
             zloop_ticket_reset (self->loop, client->ticket);
 
+        if (rc == -2) {
+.if count (class.event, name = "malformed")
+            s_client_execute (client, malformed_event);
+            continue;
+.else
+            continue;       //  Malformed, but malformed_event doesn't exist
+                            //  -> discard the message
+.endif
+        }
         //  Pass to client state machine
         s_client_execute (client, s_protocol_event (self->message));
     }


### PR DESCRIPTION
referenced before assignment.
Solution: move the "malformed message" check a couple of lines down.
Also minor change in the message header text

This was a pretty silly mistake... CI should have caught it!