### PR TITLE
Problem: dup'ing a msg with a `string` field leaks memory.

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -678,7 +678,7 @@ $(class.name)_dup ($(class.name)_t *other)
 
     // Copy the rest of the fields
 .for class.field
-.   if type = "longstr" | type = "string"
+.   if type = "longstr"
     $(class.name)_set_$(name) (copy, strdup ($(class.name)_$(name) (other)));
 .   elsif type = "uuid" | type = "hash" | type = "chunk" | type = "frame" | type = "msg"
     $(class.name)_set_$(name) (copy, z$(type)_dup ($(class.name)_$(name) (other)));
@@ -687,7 +687,7 @@ $(class.name)_dup ($(class.name)_t *other)
         zlist_t *lcopy = zlist_dup ($(class.name)_$(name) (other));
         $(class.name)_set_$(name) (copy, &lcopy);
     }
-.   elsif type = "number"
+.   elsif type = "number" | type = "string"
     $(class.name)_set_$(name) (copy, $(class.name)_$(name) (other));
 .   endif
 .endfor


### PR DESCRIPTION
Solution: do not strdup `string` fields.

--

Derp... I should have run memcheck on my project before sending my previous PR.