### PR TITLE
Problem: build error with GCC7 in zproto_server_c generated code

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -465,7 +465,7 @@ engine_set_log_prefix (client_t *client, const char *string)
 {
     if (client) {
         s_client_t *self = (s_client_t *) client;
-        snprintf (self->log_prefix, sizeof (self->log_prefix) - 1,
+        snprintf (self->log_prefix, sizeof (self->log_prefix),
             "%6d:%-33s", self->unique_id, string);
     }
 }


### PR DESCRIPTION
Solution: snprintf size parameter includes the NULL terminating char
as the manpage says, so don't pass sizeof(..) - 1