### PR TITLE
Problem: zm_proto class name hardcoded in zproto

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -2260,7 +2260,7 @@ $(class.name)_test (bool verbose)
 .       endif
 .   endfor
         if (instance == 2) {
-            zm_proto_destroy (&self);
+            $(class.name:c)_destroy (&self);
             self = self_temp;
         }
     }


### PR DESCRIPTION
Solution: use $(class.name)