### PR TITLE
Problem: can't build codec with strings type (unused variable)

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -1744,7 +1744,7 @@ $(class.name)_zpl ($(class.name)_t *self, zconfig_t *parent)
                 char *$(name) = (char *) zlist_first (self->$(name));
                 while ($(name)) {
                     char *key = zsys_sprintf ("%zu", i);
-                    zconfig_putf (config, key, "%s", $(name));
+                    zconfig_putf (strings, key, "%s", $(name));
                     zstr_free (&key);
                     i++;
                     $(name) = (char *) zlist_next (self->$(name));

--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -1807,7 +1807,7 @@ $(class.name)_zpl ($(class.name)_t *self, zconfig_t *parent)
                 char *$(name) = (char *) zlist_first (self->$(name));
                 while ($(name)) {
                     char *key = zsys_sprintf ("%zu", i);
-                    zconfig_putf (config, key, "%s", $(name));
+                    zconfig_putf (strings, key, "%s", $(name));
                     zstr_free (&key);
                     i++;
                     $(name) = (char *) zlist_next (self->$(name));


### PR DESCRIPTION
Solution: store data in appropriate zconfig_t variable