### PR TITLE
Problem: class_dup leaks class_routing_id

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -925,7 +925,7 @@ $(class.name)_dup ($(class.name)_t *other)
     $(class.name)_t *copy = $(class.name)_new ();
 
     // Copy the routing and message id
-    $(class.name)_set_routing_id (copy, zframe_dup ($(class.name)_routing_id (other)));
+    $(class.name)_set_routing_id (copy, $(class.name)_routing_id (other));
     $(class.name)_set_id (copy, $(class.name)_id (other));
 
     // Copy the rest of the fields


### PR DESCRIPTION
Solution: don't do a second zframe_dup, as the class_set_routing_id
already does it. Note that other functions take ownership of the
object instead, but they take a double pointer to do it safely,
while class_set_routing_id does not so to avoid breaking API this
solution has to be adopted instead