### PR TITLE
Problem: can't install zproto rpm on CentOS

### DIFF
--- a/packaging/redhat/zproto.spec
+++ b/packaging/redhat/zproto.spec
@@ -41,7 +41,7 @@ make install DESTDIR=%{buildroot} %{?_smp_mflags}
 
 %files
 %defattr(-,root,root)
-%{_bindir}
+%{_bindir}/*.gsl
 %{_mandir}/man7/*
 %doc README.md
 %doc README.txt


### PR DESCRIPTION
Solution: do not own /usr/bin, but all gsl files inside