### PR TITLE
Problem: new_zpl leaks memory for messages w/o fields

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -2186,6 +2186,7 @@ $(class.name)_test (bool verbose)
             $(class.name)_recv (self, input);
         else {
             self = $(class.name)_new_zpl (config);
+            assert (self);
             zconfig_destroy (&config);
         }
         if (instance < 2)

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -733,14 +733,18 @@ $(class.name)_t *
         self->routing_id = frame;
     }
 
-    zconfig_t *content = zconfig_locate (config, "content");
-    if (!content) {
-        zsys_error ("Can't find 'content' section");
-        return NULL;
-    }
+    zconfig_t *content = NULL;
     switch (self->id) {
 .for class.message
         case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   if count (field) > 0
+            content = zconfig_locate (config, "content");
+            if (!content) {
+                zsys_error ("Can't find 'content' section");
+                $(class.name)_destroy (&self);
+                return NULL;
+            }
+.   endif
 .   for field where !defined (value)
 .       if type = "number"
             {


### PR DESCRIPTION
Solution: do not return NULL for messages w/o fields, allways destroy the memory