### PR TITLE
Problem: memory leak when calling generated _dup with longstr

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -944,7 +944,7 @@ $(class.name)_dup ($(class.name)_t *other)
     {
         const char *str = $(class.name)_$(name) (other);
         if (str) {
-            $(class.name)_set_$(name) (copy, strdup (str));
+            $(class.name)_set_$(name) (copy, str);
         }
     }
 .   elsif type = "hash" | type = "chunk" | type = "frame" | type = "msg"


### PR DESCRIPTION
Solution: remove extra strdup, it is called by _set_$(name) method anyway