### PR TITLE
Problem: Test crashes when msg contains uuid or chunk fields

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -2269,26 +2269,26 @@ $(class.name)_test (bool verbose)
         assert (streq ((char *) zhash_cursor ($(name)), "Name"));
 .           endif
         zhash_destroy (&$(name));
-        if (instance == 1)
+        if (instance == 2)
             zhash_destroy (&$(message.name)_$(name));
 .       elsif type = "chunk"
         assert (memcmp (zchunk_data ($(class.name)_$(name) (self)), "$(->test.?"Captcha Diem":)", $(->test.??12?string.length(->test.?"Captcha Diem"):)) == 0);
-        if (instance == 1)
+        if (instance == 2)
             zchunk_destroy (&$(message.name)_$(name));
 .       elsif type = "frame"
         assert (zframe_streq ($(class.name)_$(name) (self), "$(->test.?"Captcha Diem":)"));
-        if (instance == 1)
+        if (instance == 2)
             zframe_destroy (&$(message.name)_$(name));
 .       elsif type = "msg"
         assert (zmsg_size ($(class.name)_$(name) (self)) == 1);
         char *content = zmsg_popstr ($(class.name)_$(name) (self));
         assert (streq (content, "$(->test.?"Captcha Diem":)"));
         zstr_free (&content);
-        if (instance == 1)
+        if (instance == 2)
             zmsg_destroy (&$(message.name)_$(name));
 .       elsif type = "uuid"
         assert (zuuid_eq ($(message.name)_$(name), zuuid_data ($(class.name)_$(name) (self))));
-        if (instance == 1)
+        if (instance == 2)
             zuuid_destroy (&$(message.name)_$(name));
 .       endif
 .   endfor


### PR DESCRIPTION
Solution: Destroy composite test data (uuid, chunk, etc)... after last test
iteration.