### PR TITLE
Problem: generated C selftest fails on windows

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -2307,6 +2307,9 @@ $(class.name)_test (bool verbose)
     zsock_destroy (&input);
     zsock_destroy (&output);
 .endif
+#if defined (__WINDOWS__)
+    zsys_shutdown();
+#endif
     //  @end
 
     printf ("OK\\n");

--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -2302,6 +2302,9 @@ $(class.name)_test (bool verbose)
     zconfig_destroy (&config);
     zsock_destroy (&input);
     zsock_destroy (&output);
+#if defined (__WINDOWS__)
+    zsys_shutdown();
+#endif
     //  @end
 
     printf ("OK\\n");


### PR DESCRIPTION
Solution: Call zsys_shutdown expicitely on windows platform
See also https://github.com/zeromq/czmq/issues/1751