### PR TITLE
Allow cstype to be string

### DIFF
--- a/src/zproto_lib_cs.gsl
+++ b/src/zproto_lib_cs.gsl
@@ -44,6 +44,8 @@ function set_cs_defaults ()
                 else
                     echo "E: bad size $(size) for $(name)"
                 endif
+            elsif type = "string"
+                field.cstype = "string"
             endif
             for class.field as cfield where cfield.name = field.name
                 if cfield.type <> field.type


### PR DESCRIPTION
(zproto_codec_cs.gsl 307) Undefined expression: cstype
error triggered when xml field of type=string contains a value attribute:
`<field name = "protocol" type = "string" value = "FILEMQ">Constant "FILEMQ"</field>`