### PR TITLE
Problem: zsock_set_zap_domain uses NULL

### DIFF
--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -879,7 +879,7 @@ s_server_config_service (s_server_t *self)
             char *mechanism = zconfig_get (section, "mechanism", "null");
             char *domain = zconfig_get (section, "domain", NULL);
             if (domain)
-                zsock_set_zap_domain (self->router, NULL);
+                zsock_set_zap_domain (self->router, domain);
             if (streq (mechanism, "null")) {
                 zsys_notice ("server is using NULL security");
             }


### PR DESCRIPTION
This bug is old, and was fixed a while in malamute project but never backported here. 
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>