### PR TITLE
Problem: zproto client works with messages with msg type only

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,10 +670,12 @@ To simplify the delivery of a conventional non-actor API, you can define methods
         <field name = "content" type = "string" />
     </method>
 
-    <method name = "recv" return = "content" immediate = "1">
+    <method name = "recv" return = "content" immediate = "1" virtual ="1">
     Receive next message from server. Returns the message content, as a string,
     if any. The caller should not modify or free this string. This method is
     defined as "immediate" and so does not send any message to the client actor.
+    Virtual 1 means recv method returns msg part of incomming message. Virtual 0 means
+    recv returns 0/-1 and message parts are accessible using client methods.
         <accept reply = "MESSAGE" />
     </method>
 

--- a/README.txt
+++ b/README.txt
@@ -625,10 +625,12 @@ To simplify the delivery of a conventional non-actor API, you can define methods
         <field name = "content" type = "string" />
     </method>
 
-    <method name = "recv" return = "content" immediate = "1">
+    <method name = "recv" return = "content" immediate = "1" virtual = "1">
     Receive next message from server. Returns the message content, as a string,
     if any. The caller should not modify or free this string. This method is
     defined as "immediate" and so does not send any message to the client actor.
+    Virtual 1 means recv method returns msg part of incomming message. Virtual 0 means
+    recv returns 0/-1 and message parts are accessible using client methods.
         <accept reply = "MESSAGE" />
     </method>
 

--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -257,6 +257,9 @@ for class.recv
         method.cname = "$(name:c)"
         method.pattern = ""
         method.return = ""
+        if recv.virtual = 0
+            method.return = "0"
+        endif
         for proto.message where name = -1.cname
             for field
                 copy field to method
@@ -268,7 +271,7 @@ for class.recv
             pattern += "$(field.bin_pattern:)"
             #   We must return a single msg type
             if type = "msg"
-                method.return = name
+                method.return = "self->$(name)"
             endif
         endfor
         if method.return = ""
@@ -386,10 +389,17 @@ endif
 .   endfor
 .endfor
 .for class.recv
+.   if recv.virtual ?= 0
+    <method name = "recv">
+        Receive message from server; Returns >= 0 if successful, -1 if interrupted.
+        <return type = "integer" />
+    </method>
+.else
     <method name = "recv">
         Receive message from server; caller destroys message when done
         <return type = "zmsg" fresh = "1" />
     </method>
+.   endif
 
     <method name = "command">
         Return last received command. Can be one of these values:
@@ -512,9 +522,15 @@ $(CLASS.EXPORT_MACRO)int
 .   endfor
 .endfor
 .for class.recv
+.   if recv.virtual = 0
+//  Receive message from server; Returns >= 0 if successful, -1 if interrupted.
+$(CLASS.EXPORT_MACRO)int
+    $(class.name)_recv ($(class.name)_t *self);
+.   else
 //  Receive message from server; caller destroys message when done
 $(CLASS.EXPORT_MACRO)zmsg_t *
     $(class.name)_recv ($(class.name)_t *self);
+.   endif
 
 //  Return last received command. Can be one of these values:
 .   for message
@@ -1517,13 +1533,21 @@ $(class.name)_$(.method:c) ($(class.name)_t *self$(args))
 //  ---------------------------------------------------------------------------
 //  Receive message from server; caller destroys message when done
 
+.   if recv.virtual = 0
+int
+.   else
 zmsg_t *
+.   endif
 $(class.name)_recv ($(class.name)_t *self)
 {
     zstr_free (&self->command);
     self->command = zstr_recv (self->msgpipe);
     if (!self->command)
+.   if recv.virtual = 0
+        return -1;              //  Interrupted
+.   else
         return NULL;            //  Interrupted
+.   endif
 
 .   for message as method
 .   if index () > 1
@@ -1535,10 +1559,14 @@ $(class.name)_recv ($(class.name)_t *self)
 , &self->$(name)\
 .       endfor
 );
-        return self->$(return);
+        return $(return);
     }
 .   endfor
+.   if recv.virtual = 0
+    return -1;
+.   else
     return NULL;
+.   endif
 }
 
 //  ---------------------------------------------------------------------------

--- a/src/zproto_lib.gsl
+++ b/src/zproto_lib.gsl
@@ -74,6 +74,11 @@ function set_defaults ()
             endfor
         endfor
     endfor
+
+#   for recv the default is virtual="1", be backward compatible
+    for class.recv
+        recv.virtual ?= 1
+    endfor
 endfunction
 
 function resolve_types ()


### PR DESCRIPTION
Solution: adapt term virtual for recv methods, so virtual="0" will
change prototype in a following way

    // virtual == 1
    zmsg_t * foo_client_recv (foo_client_t *self);
    // virtual == 0
    int foo_client_recv (foo_client_t *self);

This is a bit similar to virtual="0" in zproto_codec_c

    // virtual == 1
    zmsg_t * foo_msg_recv (void *socket);
    // virtual == 0
    int foo_msg_recv (foo_msg_t *self, void *socket);

Defaults for codec_c and client_c are different to maintain
backward compatibility.