### PR TITLE
Problem: can't split protocol and server (client) implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Your input to the code generator is two XML files (without schemas, DTDs, entity
         title = "Hello server"
         script = "zproto_server_c"
         protocol_class = "hello_msg"
+        protocol_dir = ""
         package_dir = "../include"
         source_dir = "."
         project_header = "hello.h"
@@ -189,7 +190,7 @@ Your input to the code generator is two XML files (without schemas, DTDs, entity
         </state>
     </class>
 
-You will also need a minimal 'hello_msg.xml' as below. It's name is defined line 5 of 'hello_server.xml', as 'protocol_class'.
+You will also need a minimal 'hello_msg.xml' as below. It's name is defined line 5 of 'hello_server.xml', as 'protocol_class'. Variable 'protocol_dir' allows developer to split protocol from client/server implementation to different projects.
 
     <class
         name = "hello_msg"

--- a/README.txt
+++ b/README.txt
@@ -144,7 +144,7 @@ Your input to the code generator is two XML files (without schemas, DTDs, entity
         </state>
     </class>
 
-You will also need a minimal 'hello_msg.xml' as below. It's name is defined line 5 of 'hello_server.xml', as 'protocol_class'.
+You will also need a minimal 'hello_msg.xml' as below. It's name is defined line 5 of 'hello_server.xml', as 'protocol_class'. Variable 'protocol_dir' allows developer to split protocol from client/server implementation to different projects.
 
     <class
         name = "hello_msg"

--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -19,7 +19,8 @@ generate_dot ()
 set_defaults ()
 
 #   Load message structures for this engine
-global.proto = xml.load_file (class.protocol_class + ".xml")
+protocol_file = class.protocol_dir + class.protocol_class + ".xml"
+global.proto = xml.load_file (protocol_file)
 class.proto = class.protocol_class
 
 #   Lowercase state/event/action names

--- a/src/zproto_lib.gsl
+++ b/src/zproto_lib.gsl
@@ -79,6 +79,8 @@ function set_defaults ()
     for class.recv
         recv.virtual ?= 1
     endfor
+
+    class.protocol_dir ?= ""
 endfunction
 
 function resolve_types ()

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -22,7 +22,8 @@ generate_dot ()
 set_defaults ()
 
 #   Load message structures for this engine
-global.proto = xml.load_file (class.protocol_class + ".xml")
+protocol_file = class.protocol_dir + class.protocol_class + ".xml"
+global.proto = xml.load_file (protocol_file)
 class.proto = class.protocol_class
 
 #   Lowercase state/event/action names


### PR DESCRIPTION
Solution: add and document protocol_dir option, which allows you to
refer to protocol from different git repository.