### PR TITLE
Problem: no sanity check in (class)_is and (class)_destroy

### DIFF
--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -57,9 +57,9 @@ set_defaults ()
     </destructor>
 
     <method name = "is" singleton = "1">
-        Parse a zmsg_t and decides whether it is $(class.name). Returns
-        true if it is, false otherwise. Doesn't destroy or modify the
-        original message.
+        Parses a zmsg_t and decides whether it carries a $(class.name).
+        Returns true if it does, false otherwise.
+        Doesn't destroy or modify the original message.
         <argument name = "msg" type = "zmsg" />
         <return type = "boolean" />
     </method>
@@ -396,9 +396,9 @@ $(CLASS.EXPORT_MACRO)$(class.name)_t *
 $(CLASS.EXPORT_MACRO)void
     $(class.name)_destroy ($(class.name)_t **self_p);
 
-//  Parse a zmsg_t and decides whether it is $(class.name). Returns
-//  true if it is, false otherwise. Doesn't destroy or modify the
-//  original message.
+//  Parses a zmsg_t and decides whether it carries a $(class.name).
+//  Returns true if it does, false otherwise.
+//  Doesn't destroy or modify the original message.
 $(CLASS.EXPORT_MACRO)bool
     $(class.name)_is (zmsg_t *msg_p);
 
@@ -1066,9 +1066,9 @@ $(class.name)_destroy ($(class.name)_t **self_p)
     }
 }
 
-//  Parse a zmsg_t and decides whether it is $(class.name). Returns
-//  true if it is, false otherwise. Doesn't destroy or modify the
-//  original message.
+//  Parses a zmsg_t and decides whether it carries a $(class.name).
+//  Returns true if it does, false otherwise.
+//  Doesn't destroy or modify the original message.
 bool
 $(class.name)_is (zmsg_t *msg)
 {

--- a/src/zproto_codec_c_v1.gsl
+++ b/src/zproto_codec_c_v1.gsl
@@ -1044,6 +1044,8 @@ $(class.name)_destroy ($(class.name)_t **self_p)
     assert (self_p);
     if (*self_p) {
         $(class.name)_t *self = *self_p;
+.# TODO: If the class has some magic header or checksum, this is a good place
+.# to test validity of the call (that we asked to destroy correct object type)
 
         //  Free class properties
         zframe_destroy (&self->routing_id);
@@ -1072,6 +1074,7 @@ $(class.name)_is (zmsg_t *msg)
 {
     if (msg == NULL)
         return false;
+    assert (zmsg_is (msg));
 
     zframe_t *frame = zmsg_first (msg);
     if (frame == NULL)


### PR DESCRIPTION
Solution: in *_is() make sure we are inspecting a zmsg_t.
It is more complicated for *_destroy(), since classes lack a generic
magic string, checksum, CRC or some other validation that a memory
range is indeed an instance of expected structure. So left a comment.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>