### PR TITLE
Problem: OSX build broken due to c99 style for loop

### DIFF
--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -805,7 +805,8 @@ $(class.name)_t *
             if (zstrings) {
                 zlist_t *strings = zlist_new ();
                 zlist_autofree (strings);
-                for (zconfig_t *child = zconfig_child (zstrings);
+                zconfig_t *child;
+                for (child = zconfig_child (zstrings);
                                 child != NULL;
                                 child = zconfig_next (child))
                 {
@@ -820,7 +821,8 @@ $(class.name)_t *
             if (zhash) {
                 zhash_t *hash = zhash_new ();
                 zhash_autofree (hash);
-                for (zconfig_t *child = zconfig_child (zhash);
+                zconfig_t *child;
+                for (child = zconfig_child (zhash);
                                 child != NULL;
                                 child = zconfig_next (child))
                 {


### PR DESCRIPTION
Solution: declare variable before for loop to avoid issues with
extremely old and outdated systems