### PR TITLE
Allow setting source/header extension similar to zproject and fix const.

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -300,7 +300,7 @@ endif
 .endtemplate
 .#  This is the API for the client
 .if switches.zproject ?= 1
-.   file.delete ("$(class.package_dir)/$(class.name).h")
+.   file.delete ("$(class.package_dir)/$(class.name).$(class.header_ext)")
 .   directory.create ("../api")
 .   output "../api/$(class.name).api"
 <!--
@@ -453,7 +453,7 @@ $(api.:)
     </method>
 </class>
 .else
-.   output "$(class.package_dir)/$(class.name).h"
+.   output "$(class.package_dir)/$(class.name).$(class.header_ext)"
 /*  =========================================================================
     $(class.name) - $(class.title:)
 
@@ -632,7 +632,7 @@ typedef enum {
 } event_t;
 
 //  Names for state machine logging and error reporting
-static char *
+static const char *
 s_state_name [] = {
     "(NONE)",
 .for class.state
@@ -640,7 +640,7 @@ s_state_name [] = {
 .endfor
 };
 
-static char *
+static const char *
 s_event_name [] = {
     "(NONE)",
 .for class.event
@@ -1657,7 +1657,7 @@ $(source.:)
 .   endfor
 .endfor
 .#  Generate source file first time only
-.source_file = "$(class.name).c"
+.source_file = "$(class.name).$(class.source_ext)"
 .if !file.exists (source_file)
 .   output source_file
 /*  =========================================================================
@@ -1681,8 +1681,8 @@ $(source.:)
 #include "$(class.project_header)"
 .endif
 //  TODO: Change these to match your project's needs
-#include "$(class.package_dir)/$(class.protocol_class).h"
-#include "$(class.package_dir)/$(class.name).h"
+#include "$(class.package_dir)/$(class.protocol_class).$(class.header_ext)"
+#include "$(class.package_dir)/$(class.name).$(class.header_ext)"
 
 //  Forward reference to method arguments structure
 typedef struct _client_args_t client_args_t;

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -33,7 +33,7 @@ generate_bnf ()
 set_defaults ()
 .endtemplate
 .if switches.zproject ?= 1 & switches.private?0 <> 1
-.   file.delete ("$(class.package_dir)/$(class.name).h")
+.   file.delete ("$(class.package_dir)/$(class.name).$(class.header_ext)")
 .   directory.create ("../api")
 .   output "../api/$(class.name).api"
 <!--
@@ -268,7 +268,7 @@ set_defaults ()
 .   endfor
 </class>
 .else
-.   output "$(class.package_dir)/$(class.name).h"
+.   output "$(class.package_dir)/$(class.name).$(class.header_ext)"
 /*  =========================================================================
     $(class.name) - $(class.title:)
 
@@ -504,7 +504,7 @@ $(CLASS.EXPORT_MACRO)void
 
 #endif
 .endif
-.output "$(class.source_dir)/$(class.name).c"
+.output "$(class.source_dir)/$(class.name).$(class.source_ext)"
 /*  =========================================================================
     $(class.name) - $(class.title:)
 
@@ -539,7 +539,7 @@ $(CLASS.EXPORT_MACRO)void
 .if defined (class.project_header)
 #include "$(class.project_header)"
 .endif
-#include "$(class.package_dir)/$(class.name).h"
+#include "$(class.package_dir)/$(class.name).$(class.header_ext)"
 
 //  Structure of our class
 

--- a/src/zproto_lib.gsl
+++ b/src/zproto_lib.gsl
@@ -15,6 +15,12 @@ function expand_headers ()
         if !defined (message.id)
             message.id = item ()
         endif
+        if !defined (class.header_ext)
+            class.header_ext = "h"
+        endif
+        if !defined (class.source_ext)
+            class.source_ext = "c"
+        endif
         for field where item () = 1
             for class.header
                 for field as hfield

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -110,7 +110,7 @@ endfor
 
 .endtemplate
 .#  This is the API for the server
-.output "$(class.package_dir)/$(class.name).h"
+.output "$(class.package_dir)/$(class.name).$(class.header_ext)"
 /*  =========================================================================
     $(class.name) - $(class.title:)
 
@@ -252,7 +252,7 @@ typedef enum {
 } event_t;
 
 //  Names for state machine logging and error reporting
-static char *
+static const char *
 s_state_name [] = {
     "(NONE)",
 .for class.state
@@ -260,7 +260,7 @@ s_state_name [] = {
 .endfor
 };
 
-static char *
+static const char *
 s_event_name [] = {
     "(NONE)",
     "terminate",
@@ -1158,7 +1158,7 @@ $(class.name) (zsock_t *pipe, void *args)
     assert (self);
     zsock_signal (pipe, 0);
     //  Actor argument may be a string used for logging
-    self->log_prefix = args? (char *) args: "";
+    self->log_prefix = args? (char *) args: (char*)"";
 
     //  Set-up server monitor to watch for config file changes
     engine_set_monitor ((server_t *) self, 1000, s_watch_server_config);
@@ -1173,7 +1173,7 @@ $(class.name) (zsock_t *pipe, void *args)
     s_server_destroy (&self);
 }
 .#  Generate source file first time only
-.source_file = "$(class.name).c"
+.source_file = "$(class.name).$(class.source_ext)"
 .if !file.exists (source_file)
 .   output source_file
 /*  =========================================================================
@@ -1197,8 +1197,8 @@ $(class.name) (zsock_t *pipe, void *args)
 #include "$(class.project_header)"
 .endif
 //  TODO: Change these to match your project's needs
-#include "$(class.package_dir)/$(class.protocol_class).h"
-#include "$(class.package_dir)/$(class.name).h"
+#include "$(class.package_dir)/$(class.protocol_class).$(class.header_ext)"
+#include "$(class.package_dir)/$(class.name).$(class.header_ext)"
 
 //  ---------------------------------------------------------------------------
 //  Forward declarations for the two main classes we use here
@@ -1307,7 +1307,7 @@ $(class.name)_test (bool verbose)
         printf ("\\n");
 
     //  @selftest
-    zactor_t *server = zactor_new ($(class.name), "server");
+    zactor_t *server = zactor_new ($(class.name), (char*)"server");
     if (verbose)
         zstr_send (server, "VERBOSE");
     zstr_sendx (server, "BIND", "ipc://@/$(class.name)", NULL);


### PR DESCRIPTION
This is mostly to allow `.hpp` or `.cpp` to be set with `header_ext` and `source_ext` variables.  O.w., even in a zproject with `use-cxx = "True"` zproto makes `.h/.c`.

A couple of const-correct fixes snuck in also.  Hopefully it's okay to include two fixes in one PR.  O.w. I can separate.