### PR TITLE
zproto_dot fix to correctly handle levels of inheritance greater than one

### DIFF
--- a/src/zproto_dot.gsl
+++ b/src/zproto_dot.gsl
@@ -41,13 +41,36 @@ function generate_dot
     >digraph "$(class.name)" {
 
     # Mark super-states (those, which are inherited by some other state)
+    for class.state as state where defined (inherit)
+         > "$(state.name)" -> "$(state.inherit)" [style=dotted,arrowhead=empty]
+    endfor
+
+    for class.state
+        >
+        > "$(name)" [shape = "doublecircle"];
+
+        for event
+            generate_event (event, 0)
+        endfor
+
+    endfor
+    >}
+
+endfunction
+
+function generate_dot_old
+    output "$(class.name)_old.dot"
+    >## Automatically generated from $(class.name).xml by gsl
+    >digraph "$(class.name)" {
+
+    # Mark super-states (those, which are inherited by some other state)
     for class.state where defined (inherit)
         for class.state as superstate where name = state.inherit
             superstate.superstate = 1
         endfor
     endfor
 
-    # Go through all classes except superstates, which does not have
+    # GO through all classes except superstates, which does not have
     # an entry point and are merged with their descendants
     for class.state where ! defined (superstate)
         >
@@ -71,4 +94,5 @@ function generate_dot
     >}
 
 endfunction
+
 .endtemplate


### PR DESCRIPTION
Previously `zproto_dot.gsl` produced wrong results if there was a super-super-state.  When there was merely a super-state it duplicated the event nodes for the base state and each superstate which added unwanted (by me at least) visual complexity to the resulting graph.  

This commit produces a graphviz dot file where state inheritance is shown as a directed edge between the two states and all event nodes are shown once and only connected to the state for which they were directly defined.

The first example below shows old output on a generated server I'm working on and the second shows the new output.  It is the `connected` state which is both a super- and a sub-state.   

The original function is kept as `generate_dot_old` but maybe it should be removed?

Old `zproto_dot.gsl` output

![zperf_server_old](https://user-images.githubusercontent.com/209537/66718408-98cbd400-edb1-11e9-8fd6-5a0b043d200e.png)

New `zproto_dot.gsl` output

![zperf_server](https://user-images.githubusercontent.com/209537/66718410-9e291e80-edb1-11e9-8a4f-516f6036b7ad.png)

