### PR TITLE
Fix regression from header_ext/source_ext addition

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -23,6 +23,13 @@ protocol_file = class.protocol_dir + class.protocol_class + ".xml"
 global.proto = xml.load_file (protocol_file)
 class.proto = class.protocol_class
 
+if !defined (class.header_ext)
+  class.header_ext = "h"
+endif
+if !defined (class.source_ext)
+  class.source_ext = "c"
+endif
+
 #   Lowercase state/event/action names
 for class.state
     state.name = "$(name)"

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -2382,7 +2382,7 @@ $(class.name)_test (bool verbose)
     zhash_insert ($(message.name)_$(field.name), "$(test.name)", "$(test.)");
 .               endfor
 .           else
-    zhash_insert ($(message.name)_$(field.name), "Name", "Brutus");
+    zhash_insert ($(message.name)_$(field.name), "Name", (void*)"Brutus");
 .           endif
     $(class.name)_set_$(name) (self, &$(message.name)_$(name));
 .       elsif type = "chunk" | type = "frame"

--- a/src/zproto_server_c.gsl
+++ b/src/zproto_server_c.gsl
@@ -26,6 +26,14 @@ protocol_file = class.protocol_dir + class.protocol_class + ".xml"
 global.proto = xml.load_file (protocol_file)
 class.proto = class.protocol_class
 
+if !defined (class.header_ext)
+  class.header_ext = "h"
+endif
+if !defined (class.source_ext)
+  class.source_ext = "c"
+endif
+
+
 #   Lowercase state/event/action names
 for class.state
     state.name = "$(name)"


### PR DESCRIPTION
I failed to realize that `zproto_client_c.gsl` and `zproto_server_c.gsl` do not call `expand_headers()` like `zproto_codec_c.gsl` does so they were not picking up the default setting of `header_ext` and `source_ext` that were recently introduced.  This commit sets these to default `.h/.c`.

There is also a small cast fix included to make `const` pedantic compilers happy.