### PR TITLE
Problem: zproto with docker image hard to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM zeromqorg/gsl
 
-RUN apt-get install -y build-essential libtool autoconf automake
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y -q
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y -q --force-yes build-essential autoconf automake libtool pkg-config
+
+COPY packaging/docker/run_zproto.sh /usr/local/bin/run_zproto.sh
 
 COPY . /tmp/zproto
 WORKDIR /tmp/zproto
 RUN ( ./autogen.sh; ./configure; make check; make install )
+RUN rm -rf /tmp/zproto
+ENTRYPOINT ["run_zproto.sh"]

--- a/packaging/docker/run_zproto.sh
+++ b/packaging/docker/run_zproto.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# $BUILD_DIR points to directory holding sources
+BUILD_DIR=${BUILD_DIR-.}
+cd "$BUILD_DIR" || exit 1
+gsl "$@"


### PR DESCRIPTION
Solution: Add a run script as entry point that takes gsl parameters