### PR TITLE
problem: no way to get a encoded message out of a msg

### DIFF
--- a/include/zproto_example.h
+++ b/include/zproto_example.h
@@ -12,26 +12,26 @@
      * The XML model used for this code generation: zproto_example.xml, or
      * The code generation script that built this file: zproto_codec_c
     ************************************************************************
-    Copyright (C) 2014 the Authors                                         
-                                                                           
-    Permission is hereby granted, free of charge, to any person obtaining  
-    a copy of this software and associated documentation files (the        
-    "Software"), to deal in the Software without restriction, including    
-    without limitation the rights to use, copy, modify, merge, publish,    
-    distribute, sublicense, and/or sell copies of the Software, and to     
-    permit persons to whom the Software is furnished to do so, subject to  
-    the following conditions:                                              
-                                                                           
+    Copyright (C) 2014 the Authors
+
+    Permission is hereby granted, free of charge, to any person obtaining
+    a copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, sublicense, and/or sell copies of the Software, and to
+    permit persons to whom the Software is furnished to do so, subject to
+    the following conditions:
+
     The above copyright notice and this permission notice shall be included
-    in all copies or substantial portions of the Software.                 
-                                                                           
+    in all copies or substantial portions of the Software.
+
     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF             
-    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   
-    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   
-    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      
-    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
     =========================================================================
 */
 
@@ -41,7 +41,7 @@
 /*  These are the zproto_example messages:
 
     LOG - Log an event.
-        sequence            number 2    
+        sequence            number 2
         version             number 2    Version
         level               number 1    Log severity level
         event               number 1    Type of event
@@ -52,12 +52,12 @@
         data                longstr     Actual log message
 
     STRUCTURES - This message contains a list and a hash.
-        sequence            number 2    
+        sequence            number 2
         aliases             strings     List of strings
         headers             hash        Other random properties
 
     BINARY - Deliver a multi-part message.
-        sequence            number 2    
+        sequence            number 2
         flags               octets [4]  A set of flags
         public_key          chunk       Our public key
         identifier          uuid        Unique identity
@@ -65,7 +65,7 @@
         content             msg         Message to be delivered
 
     TYPES - Demonstrate custom-defined types
-        sequence            number 2    
+        sequence            number 2
         client_forename     string      Given name
         client_surname      string      Family name
         client_mobile       string      Mobile phone number
@@ -101,12 +101,21 @@ typedef struct _zproto_example_t zproto_example_t;
 zproto_example_t *
     zproto_example_new (void);
 
+//  Create a new zproto_example from zpl/zconfig_t *
+zproto_example_t *
+    zproto_example_new_zpl (zconfig_t *config);
+
 //  Destroy a zproto_example instance
 void
     zproto_example_destroy (zproto_example_t **self_p);
 
+//  Create a deep copy of a zproto_example instance
+zproto_example_t *
+    zproto_example_dup (zproto_example_t *other);
+
 //  Receive a zproto_example from the socket. Returns 0 if OK, -1 if
-//  there was an error. Blocks if there is no message waiting.
+//  the read was interrupted, or -2 if the message is malformed.
+//  Blocks if there is no message waiting.
 int
     zproto_example_recv (zproto_example_t *self, zsock_t *input);
 
@@ -114,10 +123,20 @@ int
 int
     zproto_example_send (zproto_example_t *self, zsock_t *output);
 
+//  Encode the first frame of zproto_example. Does not destroy it. Returns the frame if
+//  OK, else NULL.
+zframe_t *
+zproto_example_encode (zproto_example_t *self);
+
+
 
 //  Print contents of message to stdout
 void
     zproto_example_print (zproto_example_t *self);
+
+//  Export class as zconfig_t*. Caller is responsibe for destroying the instance
+zconfig_t *
+    zproto_example_zpl (zproto_example_t *self, zconfig_t* parent);
 
 //  Get/set the message routing id
 zframe_t *

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -119,6 +119,11 @@ set_defaults ()
     <argument name = "output" type = "zsock" />
     <return type = "integer" />
 </method>
+
+<method name = "encode">
+    Encode the first frame of $(class.name). Does not destroy it. Returns the frame if OK, else NULL.
+    <return type = "zframe" />
+</method>
 .   endif
 
 <method name = "print">
@@ -388,6 +393,11 @@ $(CLASS.EXPORT_MACRO)int
 //  Send the $(class.name) to the output socket, does not destroy it
 $(CLASS.EXPORT_MACRO)int
     $(class.name)_send ($(class.name)_t *self, zsock_t *output);
+
+//  Encode the first frame of $(class.name). Does not destroy it. Returns the frame if
+//  OK, else NULL.
+$(CLASS.EXPORT_MACRO)zframe_t *
+$(class.name)_encode ($(class.name)_t *self);
 
 .endif
 
@@ -1178,6 +1188,98 @@ $(class.name)_dup ($(class.name)_t *other)
 .endfor
     }
 .endmacro
+
+.macro encode_frame
+    //  Now serialize message into the frame
+.if class.pubsub = 1
+    PUT_NUMBER1 (self->id);
+    size_t topic_size = strlen (self->topic);
+    memcpy(self->needle, self->topic, topic_size + 1);
+    self->needle += topic_size + 1;
+.else
+    PUT_NUMBER2 (0xAAA0 | $(class.signature));
+    PUT_NUMBER1 (self->id);
+.endif
+.if defined (class.msg)
+    bool have_$(class.msg) = false;
+.endif
+    size_t nbr_frames = 1;              //  Total number of frames to send
+
+    switch (self->id) {
+.for class.message where count (field)
+        case $(CLASS.NAME)_$(MESSAGE.NAME):
+.   for field
+.       if type = "number"
+.           if defined (field.value)
+            PUT_NUMBER$(size) ($(value:));
+.           else
+            PUT_NUMBER$(size) (self->$(name));
+.           endif
+.       elsif type = "octets"
+            PUT_OCTETS (self->$(name), $(size));
+.       elsif type = "string"
+.           if defined (field.value)
+            PUT_STRING ("$(value:)");
+.           else
+            PUT_STRING (self->$(name));
+.           endif
+.       elsif type = "longstr"
+            if (self->$(name)) {
+                PUT_LONGSTR (self->$(name));
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty string
+.       elsif type = "strings"
+            if (self->$(name)) {
+                PUT_NUMBER4 (zlist_size (self->$(name)));
+                char *$(name) = (char *) zlist_first (self->$(name));
+                while ($(name)) {
+                    PUT_LONGSTR ($(name));
+                    $(name) = (char *) zlist_next (self->$(name));
+                }
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty string array
+.       elsif type = "hash"
+            if (self->$(name)) {
+                PUT_NUMBER4 (zhash_size (self->$(name)));
+                char *item = (char *) zhash_first (self->$(name));
+                while (item) {
+                    PUT_STRING (zhash_cursor (self->$(name)));
+                    PUT_LONGSTR (item);
+                    item = (char *) zhash_next (self->$(name));
+                }
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty hash
+.       elsif type = "chunk"
+            if (self->$(name)) {
+                PUT_NUMBER4 (zchunk_size (self->$(name)));
+                memcpy (self->needle,
+                        zchunk_data (self->$(name)),
+                        zchunk_size (self->$(name)));
+                self->needle += zchunk_size (self->$(name));
+            }
+            else
+                PUT_NUMBER4 (0);    //  Empty chunk
+.       elsif type = "uuid"
+            if (self->$(name))
+                zuuid_export (self->$(name), self->needle);
+            else
+                memset (self->needle, 0, ZUUID_LEN);
+            self->needle += ZUUID_LEN;
+.       elsif type = "frame"
+            nbr_frames++;
+.       elsif type = "msg"
+            nbr_frames += self->$(name)? zmsg_size (self->$(name)): 1;
+            have_$(class.msg) = true;
+.       endif
+.   endfor
+            break;
+
+.endfor
+    }
+.endmacro
 .#
 .if class.virtual ?= 1
 //  --------------------------------------------------------------------------
@@ -1700,98 +1802,13 @@ $(class.name)_send ($(class.name)_t *self, zsock_t *output)
         zframe_send (&self->routing_id, output, ZFRAME_MORE + ZFRAME_REUSE);
 
 .   calculate_frame_size ()
-    //  Now serialize message into the frame
+
     zmq_msg_t frame;
     zmq_msg_init_size (&frame, frame_size);
     self->needle = (byte *) zmq_msg_data (&frame);
-.if class.pubsub = 1
-    PUT_NUMBER1 (self->id);
-    size_t topic_size = strlen (self->topic);
-    memcpy(self->needle, self->topic, topic_size + 1);
-    self->needle += topic_size + 1;
-.else
-    PUT_NUMBER2 (0xAAA0 | $(class.signature));
-    PUT_NUMBER1 (self->id);
-.endif
-.if defined (class.msg)
-    bool have_$(class.msg) = false;
-.endif
-    size_t nbr_frames = 1;              //  Total number of frames to send
 
-    switch (self->id) {
-.for class.message where count (field)
-        case $(CLASS.NAME)_$(MESSAGE.NAME):
-.   for field
-.       if type = "number"
-.           if defined (field.value)
-            PUT_NUMBER$(size) ($(value:));
-.           else
-            PUT_NUMBER$(size) (self->$(name));
-.           endif
-.       elsif type = "octets"
-            PUT_OCTETS (self->$(name), $(size));
-.       elsif type = "string"
-.           if defined (field.value)
-            PUT_STRING ("$(value:)");
-.           else
-            PUT_STRING (self->$(name));
-.           endif
-.       elsif type = "longstr"
-            if (self->$(name)) {
-                PUT_LONGSTR (self->$(name));
-            }
-            else
-                PUT_NUMBER4 (0);    //  Empty string
-.       elsif type = "strings"
-            if (self->$(name)) {
-                PUT_NUMBER4 (zlist_size (self->$(name)));
-                char *$(name) = (char *) zlist_first (self->$(name));
-                while ($(name)) {
-                    PUT_LONGSTR ($(name));
-                    $(name) = (char *) zlist_next (self->$(name));
-                }
-            }
-            else
-                PUT_NUMBER4 (0);    //  Empty string array
-.       elsif type = "hash"
-            if (self->$(name)) {
-                PUT_NUMBER4 (zhash_size (self->$(name)));
-                char *item = (char *) zhash_first (self->$(name));
-                while (item) {
-                    PUT_STRING (zhash_cursor (self->$(name)));
-                    PUT_LONGSTR (item);
-                    item = (char *) zhash_next (self->$(name));
-                }
-            }
-            else
-                PUT_NUMBER4 (0);    //  Empty hash
-.       elsif type = "chunk"
-            if (self->$(name)) {
-                PUT_NUMBER4 (zchunk_size (self->$(name)));
-                memcpy (self->needle,
-                        zchunk_data (self->$(name)),
-                        zchunk_size (self->$(name)));
-                self->needle += zchunk_size (self->$(name));
-            }
-            else
-                PUT_NUMBER4 (0);    //  Empty chunk
-.       elsif type = "uuid"
-            if (self->$(name))
-                zuuid_export (self->$(name), self->needle);
-            else
-                memset (self->needle, 0, ZUUID_LEN);
-            self->needle += ZUUID_LEN;
-.       elsif type = "frame"
-            nbr_frames++;
-.       elsif type = "msg"
-            nbr_frames += self->$(name)? zmsg_size (self->$(name)): 1;
-            have_$(class.msg) = true;
-.       endif
-.   endfor
-            break;
+.   encode_frame ()
 
-.endfor
-    }
     //  Now send the data frame
     zmq_msg_send (&frame, zsock_resolve (output), --nbr_frames? ZMQ_SNDMORE: 0);
 
@@ -1830,6 +1847,25 @@ $(class.name)_send ($(class.name)_t *self, zsock_t *output)
     }
 .endif
     return 0;
+}
+
+//  --------------------------------------------------------------------------
+//  Encode the first frame of $(class.name). Does not destroy it. Returns the frame if
+//  OK, else NULL.
+
+zframe_t *
+$(class.name)_encode ($(class.name)_t *self)
+{
+    assert (self);
+
+.   calculate_frame_size ()
+
+    zframe_t *frame = zframe_new (NULL, frame_size);
+    self->needle = (byte *) zframe_data (frame);
+
+.   encode_frame ()
+
+    return frame;
 }
 
 

--- a/src/zproto_example.bnf
+++ b/src/zproto_example.bnf
@@ -2,11 +2,11 @@ The following ABNF grammar defines the zproto example protocol:
 
     zproto_example  = *( LOG | STRUCTURES | BINARY | TYPES )
 
-    ;  Log an event.                                                         
+    ;  Log an event.
 
     LOG             = signature %d1 sequence version level event node peer time host data
     signature       = %xAA %xA0             ; two octets
-    sequence        = number-2              ; 
+    sequence        = number-2              ;
     version         = number-2              ; Version
     level           = number-1              ; Log severity level
     event           = number-1              ; Type of event
@@ -16,27 +16,27 @@ The following ABNF grammar defines the zproto example protocol:
     host            = string                ; Originating hostname
     data            = longstr               ; Actual log message
 
-    ;  This message contains a list and a hash.                              
+    ;  This message contains a list and a hash.
 
     STRUCTURES      = signature %d2 sequence aliases headers
-    sequence        = number-2              ; 
+    sequence        = number-2              ;
     aliases         = strings               ; List of strings
     headers         = hash                  ; Other random properties
 
-    ;  Deliver a multi-part message.                                         
+    ;  Deliver a multi-part message.
 
     BINARY          = signature %d3 sequence flags public_key identifier address content
-    sequence        = number-2              ; 
+    sequence        = number-2              ;
     flags           = 4OCTET                ; A set of flags
     public_key      = chunk                 ; Our public key
     identifier      = uuid                  ; Unique identity
     address         = frame                 ; Return address as frame
     content         = msg                   ; Message to be delivered
 
-    ;  Demonstrate custom-defined types                                      
+    ;  Demonstrate custom-defined types
 
     TYPES           = signature %d4 sequence client supplier
-    sequence        = number-2              ; 
+    sequence        = number-2              ;
     client          = person                ; Client contact
     supplier        = person                ; Supplier contact
     person          = forename surname mobile email
@@ -59,7 +59,7 @@ The following ABNF grammar defines the zproto example protocol:
     ; A chunk has 4-octet length + binary contents
     chunk           = number-4 *OCTET
 
-    ; A uuid is 16-octet binary content 
+    ; A uuid is 16-octet binary content
     uuid            = 16OCTET
 
     ; A frame is zero or more octets encoded as a ZeroMQ frame


### PR DESCRIPTION
I need a way to get back an encoded message to set the new libzmq socket options ZMQ_DISCONNECT_MSG & ZMQ_HELLO_MSG

solution: add encode method that returns zframe