### PR TITLE
Feature fixbug

### DIFF
--- a/src/zproto_client_c.gsl
+++ b/src/zproto_client_c.gsl
@@ -184,13 +184,13 @@ endfunction
 function assume_property (field, allocated)
     if count (class.property, name = my.field.name) = 0
         copy field to class as property
-        for class.property where name = my.field.name
-            if my.allocated = 0
-                property.destructor =
-                my.field.destructor =
-            endif
-        endfor
     endif
+    for class.property where name = my.field.name
+        if my.allocated = 0
+            property.destructor =
+            my.field.destructor =
+        endif
+    endfor
 endfunction
 
 #   Process replies from actor, and methods to actor
@@ -271,7 +271,7 @@ for class.recv
         endif
         for proto.message where name = -1.cname
             for field
-                if count (method.field, name = field.name) = 0
+                if count (method.field, name = -1.name) = 0
                     copy field to method
                 endif
             endfor

--- a/src/zproto_codec_c.gsl
+++ b/src/zproto_codec_c.gsl
@@ -2557,28 +2557,39 @@ $(class.name)_test (bool verbose)
     config = $(class.name)_zpl (self, NULL);
     if (verbose)
         zconfig_print (config);
+
+.if class.virtual ?= 1
+    $(class.name)_send (self, output);
+
+    zmsg_destroy (&input);
+    input = zmsg_dup (output);
+    assert (input);
+
+    for (instance = 0; instance < 2; instance++) {
+.else
     //  Send twice
     $(class.name)_send (self, output);
     $(class.name)_send (self, output);
 
-.if class.virtual ?= 1
-    zmsg_destroy (&input);
-    input = zmsg_dup (output);
-    assert (input);
-.endif
     for (instance = 0; instance < 3; instance++) {
+.endif
         $(class.name)_t *self_temp = self;
+.if class.virtual ?= 1
+        if (instance < 1)
+.else
         if (instance < 2)
+.endif
             $(class.name)_recv (self, input);
         else {
             self = $(class.name)_new_zpl (config);
             assert (self);
             zconfig_destroy (&config);
         }
-        if (instance < 2)
 .if class.virtual ?= 1
+        if (instance < 1)
             assert ($(class.name)_routing_id (self) == NULL);
 .else
+        if (instance < 2)
             assert ($(class.name)_routing_id (self));
 .endif
 .if class.pubsub = 1


### PR DESCRIPTION
zproto_client_c.gsl:
1. count express error for class.recv
2. function assume_property not set destructor to none if property already exists.

take mlm_client.xml of project malamute for testing

zproto_codec_c.gsl
1. generate bad test code for message with msg field when class.virtual=1

take example_peer_msg.xml in src/zyre_peer_example/src for testing