### PR TITLE
Problem: OBS build on sid fails

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-zproto (0.0.1) UNRELEASED; urgency=low
+zproto (0.0.1-0.1) UNRELEASED; urgency=low
 
   * Initial packaging.
 

--- a/packaging/debian/zproto.dsc.obs
+++ b/packaging/debian/zproto.dsc.obs
@@ -1,7 +1,7 @@
 Format: 3.0 (quilt)
 Binary: zproto
 Source: zproto
-Version: 1.1.0
+Version: 1.1.0-0.1
 Maintainer: zproto Developers <zeromq-dev@lists.zeromq.org>
 Architecture: any
 Build-Depends: debhelper (>= 9),


### PR DESCRIPTION
Solution: change the version format to non-native as a hack, to match
OBS' debstransform usage of 1.0 format